### PR TITLE
pin surge and colors [npm]

### DIFF
--- a/.github/workflows/_shared-docs-build-publish-surge.yml
+++ b/.github/workflows/_shared-docs-build-publish-surge.yml
@@ -53,7 +53,7 @@ jobs:
           node-version: 14
 
       - name: Install Surge
-        run: npm install -g surge
+        run: npm install -g colors@1.4.0 surge@0.23.0
 
       - name: Publish site
         if: inputs.action == 'publish'


### PR DESCRIPTION
Resolves #12 
Related to #10 

This pins the version of `surge@0.23.0`, which happens to be current version being installed.

It also separately installs `colors@1.4.0` to temporarily resolve #12, until one of either the colors package is back under control or surge pins its dependency or both.

I would like to further look into whether there's an even better way to do this. I looked around for a bit, messing with `packages-lock.json` and `npm shrinkwrap` but I didn't come up with anything viable (as I'm not well-versed in nodejs at all).