### PR TITLE
pin surge@0.23.1, remove explicit colors pin #12

### DIFF
--- a/.github/workflows/_shared-docs-build-publish-surge.yml
+++ b/.github/workflows/_shared-docs-build-publish-surge.yml
@@ -53,7 +53,7 @@ jobs:
           node-version: 14
 
       - name: Install Surge
-        run: npm install -g colors@1.4.0 surge@0.23.0
+        run: npm install -g surge@0.23.1
 
       - name: Publish site
         if: inputs.action == 'publish'


### PR DESCRIPTION
related: 
- #12 
- https://github.com/sintaxi/surge/issues/469

`surge` has updated their `colors` pin with a new release, pinning to that one

tested externally in: https://github.com/briantist/gha-junk/runs/4754282432?check_suite_focus=true

