### PR TITLE
Ignore .js and .inv files for diff

### DIFF
--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -222,7 +222,7 @@ jobs:
       - name: Get a diff of the changes
         if: steps.build-base.outputs.hash != steps.build-head.outputs.hash
         id: diff
-        uses: ansible-community/github-docs-build/actions/ansible-docs-build-diff@main
+        uses: felixfontein/github-docs-build/actions/ansible-docs-build-diff@fix-merge
         with:
           build-html-a: ${{ steps.build-base.outputs.build-html }}
           build-html-b: ${{ steps.build-head.outputs.build-html }}

--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -222,7 +222,7 @@ jobs:
       - name: Get a diff of the changes
         if: steps.build-base.outputs.hash != steps.build-head.outputs.hash
         id: diff
-        uses: felixfontein/github-docs-build/actions/ansible-docs-build-diff@fix-merge
+        uses: ansible-community/github-docs-build/actions/ansible-docs-build-diff@main
         with:
           build-html-a: ${{ steps.build-base.outputs.build-html }}
           build-html-b: ${{ steps.build-head.outputs.build-html }}

--- a/actions/ansible-docs-build-diff/action.yml
+++ b/actions/ansible-docs-build-diff/action.yml
@@ -83,10 +83,10 @@ runs:
       shell: bash
       run: |
         echo "::group::Deleting files from ${{ inputs.build-html-a }}"
-        find "${{ inputs.build-html-a }}" -name '*.js' -or -name '*.inv' -delete -print
+        find "${{ inputs.build-html-a }}" \( -name '*.js' -or -name '*.inv' \) -delete -print
         echo "::endgroup::"
         echo "::group::Deleting files from ${{ inputs.build-html-b }}"
-        find "${{ inputs.build-html-b }}" -name '*.js' -or -name '*.inv' -delete -print
+        find "${{ inputs.build-html-b }}" \( -name '*.js' -or -name '*.inv' \) -delete -print
         echo "::endgroup::"
     - name: Create diff
       id: diff

--- a/actions/ansible-docs-build-diff/action.yml
+++ b/actions/ansible-docs-build-diff/action.yml
@@ -88,6 +88,7 @@ runs:
         echo "::group::Deleting files from ${{ inputs.build-html-b }}"
         find "${{ inputs.build-html-b }}" \( -name '*.js' -or -name '*.inv' \) -delete -print
         echo "::endgroup::"
+        
     - name: Create diff
       id: diff
       uses: actions/github-script@v5

--- a/actions/ansible-docs-build-diff/action.yml
+++ b/actions/ansible-docs-build-diff/action.yml
@@ -1,6 +1,9 @@
 ---
 name: Calculate diff output between two Ansible docs builds
-description: Compare two builds of docs (HTML files) and produce diff output.
+description: |
+  Compare two builds of docs (HTML files) and produce diff output.
+
+  Please note that the input directories might be modified, as some files will be deleted.
 inputs:
   build-html-a:
     description: The path to the HTML files (set A).
@@ -75,6 +78,14 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Delete files that should not be included in the diff
+      run: |
+        echo "::group::Deleting files from ${{ inputs.build-html-a }}"
+        find "${{ inputs.build-html-a }}" -name '*.js' -or -name '*.inv' -delete -print
+        echo "::endgroup::"
+        echo "::group::Deleting files from ${{ inputs.build-html-b }}"
+        find "${{ inputs.build-html-b }}" -name '*.js' -or -name '*.inv' -delete -print
+        echo "::endgroup::"
     - name: Create diff
       id: diff
       uses: actions/github-script@v5

--- a/actions/ansible-docs-build-diff/action.yml
+++ b/actions/ansible-docs-build-diff/action.yml
@@ -79,6 +79,8 @@ runs:
   using: composite
   steps:
     - name: Delete files that should not be included in the diff
+      id: delete
+      shell: bash
       run: |
         echo "::group::Deleting files from ${{ inputs.build-html-a }}"
         find "${{ inputs.build-html-a }}" -name '*.js' -or -name '*.inv' -delete -print


### PR DESCRIPTION
This extends the ansible-docs-build-diff action to delete `.js` and `.inv` files before doing the diff. Since this is after uploading the artefact, it shouldn'd break anything :)

I'm resuing the same branch name as before so I don't have to change community.docker's main branch ;) I've tested this in https://github.com/ansible-collections/community.docker/pull/280 as well; as you can see the diff there is now only the modified HTML file.

Fixes #2.

This cannot be merged yet since one commit needs to be reverted (the one changing the workflow). I'll do that after review.