### PR TITLE
pr workflow - use merge SHA when available

### DIFF
--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -159,6 +159,19 @@ jobs:
 
             core.setOutput('skip-init', skipInit)
 
+            // when a PR is first opened, the merge sha is blank
+            // when a PR is closed, the merge branch doesn't exist
+            // so let's set a var for the PR ref we'll checkout,
+            // using the merge SHA usually, but using the merge branch
+            // if the SHA is blank.
+
+            const mergeSha = '${{ github.event.pull_request.merge_commit_sha }}'
+            if (mergeSha != '') {
+                core.setOutput('pr-checkout-ref', mergeSha)
+            } else {
+                core.setOutput('pr-checkout-ref', 'refs/pull/${{ github.event.number }}/merge')
+            }
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -199,7 +212,7 @@ jobs:
           #
           # since that also works when re-running this action for older commits of
           # a PR, **but** then we get https://github.com/ansible-community/github-docs-build/issues/3 back...
-          ref: refs/pull/${{ github.event.number }}/merge
+          ref: ${{ steps.vars.outputs.pr-checkout-ref }}
           path: ${{ steps.vars.outputs.checkout-path }}
 
       - name: Initialize the build environment (HEAD)


### PR DESCRIPTION
Related to:
- #14 
- #3 

The changes in #14 result in a failed build when the PR is closed/merged, because the special merge "branch" doesn't exist anymore.

However, I have found that `github.event.pull_request.merge_commit_sha` does exist on closed/merged/reopened PRs. It does not exist on the first opened event though (whereas the merge branch _does_).

I also did some tests showing that when both the merge SHA and the merge branch exist, the content of their checkouts are exactly the same: https://github.com/briantist/gha-junk/runs/4827842600?check_suite_focus=true

This PR sets an output var for the ref we'll be using in the PR checkout. We start with the SHA because that will either be set, or blank. If the SHA is blank, then we fall back to the merge "branch".

I believe this will cover all bases.