### PR TITLE
[experimental] generate wiki docs from action/workflow YAML

### DIFF
--- a/.github/workflows/generate-wiki-docs.yml
+++ b/.github/workflows/generate-wiki-docs.yml
@@ -10,7 +10,6 @@ on:
       - .github/workflows/_shared*
       - .github/workflows/generate-wiki-docs.yml
       - actions/**/action.yml
-  workflow_dispatch:
 
 jobs:
   generate:

--- a/.github/workflows/generate-wiki-docs.yml
+++ b/.github/workflows/generate-wiki-docs.yml
@@ -1,0 +1,49 @@
+---
+name: Generate Wiki Docs
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/_shared*
+      - .github/workflows/generate-wiki-docs.yml
+      - actions/**/action.yml
+  workflow_dispatch:
+
+jobs:
+  generate:
+    env:
+      WIKI: ${{ runner.temp }}/wiki
+      ANSIBLE_COLLECTIONS_PATHS: ${{ github.workspace }}/.internal/ansible
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Checkout wiki
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.repository }}.wiki
+          path: ${{ env.WIKI }}
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Install Ansible
+        run: pip install 'ansible-core>=2.12,<2.13' --disable-pip-version-check
+
+      - name: Generate new docs
+        run: >-
+          ansible-playbook
+          internal.gh_docs.generate_docs
+          -e "action_output_dir=$WIKI/actions"
+          -e "workflow_output_dir=$WIKI/workflows"
+
+      - name: Publish docs
+        # @v2 https://github.com/Andrew-Chen-Wang/github-wiki-action/releases/tag/v2
+        uses: Andrew-Chen-Wang/github-wiki-action@b386aca0ddc5ec22b6003ba4cb50fa0b17243f6c
+        env:  # this action is written such that the inputs must be specified as env vars
+          WIKI_DIR: ${{ env.WIKI }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_MAIL: ${{ github.event.head_commit.author.email }}
+          GH_NAME: ${{ github.event.head_commit.author.name }}[bot]
+          WIKI_PUSH_MESSAGE: 'Docs for ${{ github.repository }}/${{ github.event.head_commit.id }} : ${{ github.event.head_commit.message }}'

--- a/.github/workflows/generate-wiki-docs.yml
+++ b/.github/workflows/generate-wiki-docs.yml
@@ -1,6 +1,9 @@
 ---
 name: Generate Wiki Docs
 on:
+  pull_request: ######## TO BE REMOVED BEFORE MERGING
+    types: [opened, reopened, synchronize]
+
   push:
     branches: [main]
     paths:

--- a/.internal/ansible/ansible_collections/internal/gha_docs/README.md
+++ b/.internal/ansible/ansible_collections/internal/gha_docs/README.md
@@ -1,0 +1,3 @@
+## `internal.gha_docs`
+
+An internal collection for generating markdown docs from the actions and shared workflows in this repo.

--- a/.internal/ansible/ansible_collections/internal/gha_docs/galaxy.yml
+++ b/.internal/ansible/ansible_collections/internal/gha_docs/galaxy.yml
@@ -1,0 +1,8 @@
+---
+namespace: internal
+name: gha_docs
+description: A collection internal to this repository for generating documentation from GHA content.
+version: 0.1.0
+readme: README.md
+authors:
+  - Brian Scholer (@briantist)

--- a/.internal/ansible/ansible_collections/internal/gha_docs/meta/runtime.yml
+++ b/.internal/ansible/ansible_collections/internal/gha_docs/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: '>=2.11,<2.13'

--- a/.internal/ansible/ansible_collections/internal/gha_docs/playbooks/generate_docs.yml
+++ b/.internal/ansible/ansible_collections/internal/gha_docs/playbooks/generate_docs.yml
@@ -1,0 +1,44 @@
+---
+- hosts: localhost
+  gather_facts: false
+  vars:
+    # <root>/.internal/ansible/ansible_collections/internal/gha_docs/playbooks
+    # ^6     ^5        ^4      ^3                  ^2       ^1       ^ playbook_dir
+    repo_root: >-
+      {{
+        playbook_dir
+        | dirname
+        | dirname
+        | dirname
+        | dirname
+        | dirname
+        | dirname
+      }}
+    actions_root: '{{ repo_root }}/actions'
+    workflows_root: '{{ repo_root }}/.github/workflows'
+    output_dir: '{{ role_path }}/files/output'
+  tasks:
+    - name: Find actions
+      ansible.builtin.find:
+        paths: '{{ actions_root }}'
+        recurse: true
+        patterns: action.yml
+      register: actions
+
+    - name: Generate actions docs
+      ansible.builtin.include_role:
+        name: internal.gha_docs.generate
+      vars:
+        type: action
+        file: '{{ item.path }}'
+        output: '{{ output_dir }}/action_{{ item.path | dirname | basename }}.md'
+      loop: '{{ actions.files }}'
+
+    - name: Generate workflow docs
+      ansible.builtin.include_role:
+        name: internal.gha_docs.generate
+      vars:
+        type: workflow
+        file: '{{ item }}'
+        output: '{{ output_dir }}/workflow{{ item | basename | splitext | first }}.md'
+      with_fileglob: '{{ workflows_root }}/_shared-*.yml'

--- a/.internal/ansible/ansible_collections/internal/gha_docs/playbooks/generate_docs.yml
+++ b/.internal/ansible/ansible_collections/internal/gha_docs/playbooks/generate_docs.yml
@@ -16,7 +16,9 @@
       }}
     actions_root: '{{ repo_root }}/actions'
     workflows_root: '{{ repo_root }}/.github/workflows'
-    output_dir: '{{ role_path }}/files/output'
+    output_root: '{{ role_path }}/files/output'
+    action_output_dir: '{{ output_root }}'
+    workflow_output_dir: '{{ output_root }}'
   tasks:
     - name: Find actions
       ansible.builtin.find:
@@ -31,7 +33,7 @@
       vars:
         type: action
         file: '{{ item.path }}'
-        output: '{{ output_dir }}/action_{{ item.path | dirname | basename }}.md'
+        output: '{{ action_output_dir }}/action_{{ item.path | dirname | basename }}.md'
       loop: '{{ actions.files }}'
 
     - name: Generate workflow docs
@@ -40,5 +42,5 @@
       vars:
         type: workflow
         file: '{{ item }}'
-        output: '{{ output_dir }}/workflow{{ item | basename | splitext | first }}.md'
+        output: '{{ workflow_output_dir }}/workflow{{ item | basename | splitext | first }}.md'
       with_fileglob: '{{ workflows_root }}/_shared-*.yml'

--- a/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/files/output/.gitignore
+++ b/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/files/output/.gitignore
@@ -1,0 +1,2 @@
+**
+!.gitignore

--- a/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/meta/argument_specs.yml
+++ b/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/meta/argument_specs.yml
@@ -1,0 +1,21 @@
+---
+argument_specs:
+  main:
+    options:
+      file:
+        type: path
+        required: true
+        description: The path to the action or workflow file to parse.
+
+      type:
+        type: str
+        required: true
+        description: The type of input file.
+        choices:
+          - action
+          - workflow
+
+      output:
+        type: path
+        required: true
+        description: The path to the output file.

--- a/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/tasks/main.yml
+++ b/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+- name: Load the file
+  set_fact:
+    _src: "{{ lookup('ansible.builtin.file', file) | from_yaml }}"
+
+- name: Template the workflow docs
+  when: type == 'workflow'
+  vars:
+    full: '{{ _src }}'
+    name: '{{ _src.name }}'
+    reference: '{{ file | basename }}'
+    jobs: '{{ _src.jobs }}'
+    inputs: '{{ _src[true].workflow_call.inputs | default({}) }}'
+    outputs: '{{ _src[true].workflow_call.outputs | default({}) }}'
+  ansible.builtin.template:
+    src: workflow.md.j2
+    dest: '{{ output }}'
+    force: true
+    mode: '644'
+
+- name: Template the action docs
+  when: type == 'action'
+  vars:
+    full: '{{ _src }}'
+    name: '{{ _src.name }}'
+    reference: '{{ file | dirname | basename }}'
+    description: '{{ _src.description }}'
+    inputs: '{{ _src.inputs | default({}) }}'
+    outputs: '{{ _src.outputs | default({}) }}'
+  ansible.builtin.template:
+    src: action.md.j2
+    dest: '{{ output }}'
+    force: true
+    mode: '644'

--- a/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/templates/action.md.j2
+++ b/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/templates/action.md.j2
@@ -1,0 +1,20 @@
+# `{{ reference }}`
+## {{ name }}
+
+{{ description }}
+
+### Inputs
+| Name (✅required) | Default | Description |
+| ----------------- | ------- | ----------- |
+{% for name, inp in inputs.items() %}
+| `{{ name }}`{% if inp.required %}✅{% endif %} | {% if inp.default is defined %}{% if "\n" in inp.default %}✳ _see `action.yml` for full default value_{% else %}<code>{{ inp.default.replace('`', '\`') }}</code>{% endif %}{% endif %} | {{ (inp.description.replace("\n", '<br />')) }} |
+{% endfor %}
+
+<hr />
+
+### Outputs
+| Name | Description |
+| ---- | ----------- |
+{% for name, out in outputs.items() %}
+| `{{ name }}` | {{ (out.description | default('')).replace("\n", '<br />') }} |
+{% endfor %}

--- a/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/templates/workflow.md.j2
+++ b/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/templates/workflow.md.j2
@@ -1,0 +1,27 @@
+# `{{ reference }}`
+## {{ name }}
+
+### Jobs
+| ID  | Name | Permissions |
+| --- | ---- | ----------- |
+{% for id, job in jobs.items() %}
+| `{{ id }}` | {{ job.name | default(id) }} | {% if job.permissions is not defined %}_default_{% else %}<ul>{% for resource, access in job.permissions.items() %}<li><strong>{{ resource }}</strong>: <code>{{ access }}</code></li>{% endfor %}{% endif %} |
+{% endfor %}
+
+<hr />
+
+### Inputs
+| Name (✅required) | Type | Default | Description |
+| ----------------- | ---- | ------- | ----------- |
+{% for name, inp in inputs.items() %}
+| `{{ name }}`{% if inp.required %}✅{% endif %} | {{ inp.type }} | {% if inp.default is defined %}{% if "\n" in inp.default | string %}✳ _see `action.yml` for full default value_{% else %}<code>{{ (inp.default | string).replace('`', '\`') }}</code>{% endif %}{% endif %} | {{ (inp.description.replace("\n", '<br />')) }} |
+{% endfor %}
+
+<hr />
+
+### Outputs
+| Name | Description |
+| ---- | ----------- |
+{% for name, out in outputs.items() %}
+| `{{ name }}` | {{ (out.description | default('')).replace("\n", '<br />') }} |
+{% endfor %}


### PR DESCRIPTION
This is some messing around I did to try to generate markdown from the action and shared workflow YAML files.

I did in Ansible, as an "internal" collection with a role and playbook.

I figured, as a bonus, we could use this internal collection for some of the tests in terms of actually generating documentation (the role has an argspec 😎).

This also has a workflow that would run the Ansible, and synchronize the changes to those files to the repo's wiki.

The worklow is set to run on `push` (was going to add `workflow_dispatch` but for now leaving it out, because the commit info is not available in the event, would have to retrieve it separately).

`pull_request` trigger is added just for this PR, so I can test it a little; that must be removed before merging.