### PR TITLE
wiki docs generation - fixups and fork ops

### DIFF
--- a/.github/workflows/generate-wiki-docs.yml
+++ b/.github/workflows/generate-wiki-docs.yml
@@ -13,7 +13,7 @@ env:
   # if you want this workflow to run on your fork, you must:
   # 1) enable the wiki (and have at minimum a main/default page)
   # 2) set the GENERATE_WIKI_PAGES secret in your fork to the value "yes"
-  SHOULD_RUN: github.repository == 'ansible-community/github-docs-build' || secrets.GENERATE_WIKI_PAGES == 'yes'
+  SHOULD_RUN: secrets.GENERATE_WIKI_PAGES == 'yes' || github.repository == 'ansible-community/github-docs-build'
 
 jobs:
   generate:

--- a/.github/workflows/generate-wiki-docs.yml
+++ b/.github/workflows/generate-wiki-docs.yml
@@ -11,6 +11,10 @@ on:
 
 jobs:
   generate:
+    # if you want this workflow to run on your fork, you must:
+    # 1) enable the wiki (and have at minimum a main/default page)
+    # 2) set the GENERATE_WIKI_PAGES secret in your fork to the value "yes"
+    if: github.repository == 'ansible-community/github-docs-build' || secrets.GENERATE_WIKI_PAGES == 'yes'
     env:
       WIKI: ${{ github.workspace }}/wiki
       ANSIBLE_COLLECTIONS_PATHS: ${{ github.workspace }}/.internal/ansible

--- a/.github/workflows/generate-wiki-docs.yml
+++ b/.github/workflows/generate-wiki-docs.yml
@@ -2,7 +2,7 @@
 name: Generate Wiki Docs
 on:
   push:
-    branches: [main, 'content-docs/generate-fixups']
+    branches: [main]
     paths:
       - .github/workflows/_shared*
       - .github/workflows/generate-wiki-docs.yml

--- a/.github/workflows/generate-wiki-docs.yml
+++ b/.github/workflows/generate-wiki-docs.yml
@@ -12,8 +12,7 @@ on:
 jobs:
   generate:
     env:
-      # this path is going to be used with rsync, it MUST end in a forward slash [/]
-      WIKI: ${{ github.workspace }}/wiki/
+      WIKI: ${{ github.workspace }}/wiki
       ANSIBLE_COLLECTIONS_PATHS: ${{ github.workspace }}/.internal/ansible
     runs-on: ubuntu-latest
     steps:
@@ -43,7 +42,8 @@ jobs:
         # @v2 https://github.com/Andrew-Chen-Wang/github-wiki-action/releases/tag/v2
         uses: Andrew-Chen-Wang/github-wiki-action@b386aca0ddc5ec22b6003ba4cb50fa0b17243f6c
         env:  # this action is written such that the inputs must be specified as env vars
-          WIKI_DIR: ${{ env.WIKI }}
+          # WIKI_DIR is going to be used with rsync, it MUST end in a forward slash [/]
+          WIKI_DIR: ${{ env.WIKI }}/
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_MAIL: ${{ github.event.head_commit.author.email }}
           GH_NAME: ${{ github.event.head_commit.author.name }}[bot]

--- a/.github/workflows/generate-wiki-docs.yml
+++ b/.github/workflows/generate-wiki-docs.yml
@@ -13,7 +13,7 @@ env:
   # if you want this workflow to run on your fork, you must:
   # 1) enable the wiki (and have at minimum a main/default page)
   # 2) set the GENERATE_WIKI_PAGES secret in your fork to the value "yes"
-  SHOULD_RUN: secrets.GENERATE_WIKI_PAGES == 'yes' || github.repository == 'ansible-community/github-docs-build'
+  SHOULD_RUN: ${{ secrets.GENERATE_WIKI_PAGES == 'yes' || github.repository == 'ansible-community/github-docs-build' }}
 
 jobs:
   generate:

--- a/.github/workflows/generate-wiki-docs.yml
+++ b/.github/workflows/generate-wiki-docs.yml
@@ -2,7 +2,7 @@
 name: Generate Wiki Docs
 on:
   push:
-    branches: [main]
+    branches: [main, 'content-docs/generate-fixups']
     paths:
       - .github/workflows/_shared*
       - .github/workflows/generate-wiki-docs.yml

--- a/.github/workflows/generate-wiki-docs.yml
+++ b/.github/workflows/generate-wiki-docs.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - .github/workflows/_shared*
       - .github/workflows/generate-wiki-docs.yml
+      - .internal/ansible/**
       - actions/**/action.yml
 
 jobs:

--- a/.github/workflows/generate-wiki-docs.yml
+++ b/.github/workflows/generate-wiki-docs.yml
@@ -46,5 +46,8 @@ jobs:
           WIKI_DIR: ${{ env.WIKI }}/
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_MAIL: ${{ github.event.head_commit.author.email }}
-          GH_NAME: ${{ github.event.head_commit.author.name }}[bot]
+          # GH_NAME is going to be used raw in a URL in an unquoted commandline, it can't contain spaces
+          # it's supposed to be a username, not a name, but it doesn't need to be a valid username,
+          # at least not with GITHUB_TOKEN (for a PAT, may need to match, unsure)
+          GH_NAME: ${{ github.event.head_commit.author.username || github.repository.owner }}[bot]
           WIKI_PUSH_MESSAGE: 'Docs for ${{ github.repository }}/${{ github.event.head_commit.id }} : ${{ github.event.head_commit.message }}'

--- a/.github/workflows/generate-wiki-docs.yml
+++ b/.github/workflows/generate-wiki-docs.yml
@@ -9,33 +9,40 @@ on:
       - .internal/ansible/**
       - actions/**/action.yml
 
+env:
+  # if you want this workflow to run on your fork, you must:
+  # 1) enable the wiki (and have at minimum a main/default page)
+  # 2) set the GENERATE_WIKI_PAGES secret in your fork to the value "yes"
+  SHOULD_RUN: github.repository == 'ansible-community/github-docs-build' || secrets.GENERATE_WIKI_PAGES == 'yes'
+
 jobs:
   generate:
-    # if you want this workflow to run on your fork, you must:
-    # 1) enable the wiki (and have at minimum a main/default page)
-    # 2) set the GENERATE_WIKI_PAGES secret in your fork to the value "yes"
-    if: github.repository == 'ansible-community/github-docs-build' || secrets.GENERATE_WIKI_PAGES == 'yes'
     env:
       WIKI: ${{ github.workspace }}/wiki
       ANSIBLE_COLLECTIONS_PATHS: ${{ github.workspace }}/.internal/ansible
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - if: fromJSON(env.SHOULD_RUN)
+        uses: actions/checkout@v2
 
       - name: Checkout wiki
+        if: fromJSON(env.SHOULD_RUN)
         uses: actions/checkout@v2
         with:
           repository: ${{ github.repository }}.wiki
           path: ${{ env.WIKI }}
 
       - uses: actions/setup-python@v2
+        if: fromJSON(env.SHOULD_RUN)
         with:
           python-version: '3.9'
 
       - name: Install Ansible
+        if: fromJSON(env.SHOULD_RUN)
         run: pip install 'ansible-core>=2.12,<2.13' --disable-pip-version-check
 
       - name: Generate new docs
+        if: fromJSON(env.SHOULD_RUN)
         run: >-
           ansible-playbook
           internal.gha_docs.generate_docs
@@ -43,6 +50,7 @@ jobs:
           -e "workflow_output_dir=$WIKI/workflows"
 
       - name: Publish docs
+        if: fromJSON(env.SHOULD_RUN)
         # @v2 https://github.com/Andrew-Chen-Wang/github-wiki-action/releases/tag/v2
         uses: Andrew-Chen-Wang/github-wiki-action@b386aca0ddc5ec22b6003ba4cb50fa0b17243f6c
         env:  # this action is written such that the inputs must be specified as env vars

--- a/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/tasks/main.yml
+++ b/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/tasks/main.yml
@@ -7,7 +7,7 @@
   ansible.builtin.file:
     path: '{{ output | dirname }}'
     state: directory
-    mode: '644'
+    mode: '744'
 
 - name: Template the workflow docs
   when: type == 'workflow'

--- a/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/tasks/main.yml
+++ b/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Ensure output dir exists
   ansible.builtin.file:
-    path: '{{ output }}'
+    path: '{{ output | dirname }}'
     state: directory
     mode: '644'
 

--- a/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/tasks/main.yml
+++ b/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/tasks/main.yml
@@ -3,6 +3,12 @@
   set_fact:
     _src: "{{ lookup('ansible.builtin.file', file) | from_yaml }}"
 
+- name: Ensure output dir exists
+  ansible.builtin.file:
+    path: '{{ output }}'
+    state: directory
+    mode: '644'
+
 - name: Template the workflow docs
   when: type == 'workflow'
   vars:

--- a/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/tasks/main.yml
+++ b/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/tasks/main.yml
@@ -7,7 +7,7 @@
   ansible.builtin.file:
     path: '{{ output | dirname }}'
     state: directory
-    mode: '744'
+    mode: '755'
 
 - name: Template the workflow docs
   when: type == 'workflow'


### PR DESCRIPTION
With #21 landed, found a few issues:
- if fails on forks (unless the wiki is enabled, and the `actions/` and `workflows/` directories existed in the repo)
- the setting I was using for `GH_NAME` was wrong; it was supposed to be a username.

So this PR makes the following changes:
- we set an env var `SHOULD_RUN` that checks whether we're running in the main repo, or whether a secret named `GENERATE_WIKI_PAGES` is set to `yes`
- all steps in the job are now conditional, and only run if `SHOULD_RUN` is true
- the Ansible role to generate the docs ensures the target directory exists
- added `.internal/ansible/**` to the list of paths that trigger the workflow
- [minor] moved adding the trailing forward slash on the wiki dir to the action invocation

So, on **forks**, this workflow will no longer fail. If you _want_ it to run on your fork, you must enable the wiki, and you must set the secret in your fork.

Without the above, all of the job's steps will be skipped, however the job will still run (allocate a VM, build the action container, etc.). This is because we cannot use the `secrets` context nor the `env` context in the `jobs.<job_id>.if` conditional,s o there's no way we can use the secret trigger method AND skip the job as a whole.

---

Further thoughts: we might have more workflows (certain types of tests and other repo-level stuff, like maybe what @felixfontein proposed in #4 ), that should be opt-in or not run at all on forks. One way we can avoid putting the conditionals on every step, and instead use job-level conditionals, is to run a separate job that figures out the values, and sets outputs.

The jobs that need the information could use `needs:` to wait on that first job. I really don't like that pattern, but it's one of the only ways to get around some of the more frustrating limitations in GHA.

If we did that, we might consider a shared workflow for that initial fork-checking job, that way it can be re-used by this and future workflows.

Perhaps I will wait until the _second_ workflow that needs this pattern before implementing this...