### PR TITLE
show defined secrets in workflow docs

### DIFF
--- a/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/tasks/main.yml
+++ b/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/tasks/main.yml
@@ -17,6 +17,7 @@
     reference: '{{ file | basename }}'
     jobs: '{{ _src.jobs }}'
     inputs: '{{ _src[true].workflow_call.inputs | default({}) }}'
+    secrets: '{{ _src[true].workflow_call.secrets | default({}) }}'
     outputs: '{{ _src[true].workflow_call.outputs | default({}) }}'
   ansible.builtin.template:
     src: workflow.md.j2

--- a/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/templates/workflow.md.j2
+++ b/.internal/ansible/ansible_collections/internal/gha_docs/roles/generate/templates/workflow.md.j2
@@ -19,6 +19,15 @@
 
 <hr />
 
+### Secrets
+| Name (✅required) | Description |
+| ----------------- | ----------- |
+{% for name, sec in secrets.items() %}
+| `{{ name }}`{% if sec.required %}✅{% endif %} | {{ (sec.description.replace("\n", '<br />')) }} |
+{% endfor %}
+
+<hr />
+
 ### Outputs
 | Name | Description |
 | ---- | ----------- |


### PR DESCRIPTION
Just realized an oversight in the generated docs for shared workflows: "secrets" are defined separately from other inputs. This PR adds them to the docs (we are currently using a defined secret in the surge workflow).

Tested generation locally.