### PR TITLE
build-html - ensure artifact root matches build html root

### DIFF
--- a/.github/workflows/test-action-build-html.yml
+++ b/.github/workflows/test-action-build-html.yml
@@ -6,12 +6,12 @@ on:
     paths:
       - .test/**
       - .github/workflows/test-action-build-html.yml
-      - actions/ansibe-docs-build-html/**
+      - actions/ansible-docs-build-html/**
   pull_request:
     paths:
       - .test/**
       - .github/workflows/test-action-build-html.yml
-      - actions/ansibe-docs-build-html/**
+      - actions/ansible-docs-build-html/**
 
 jobs:
   tests:

--- a/.github/workflows/test-action-build-html.yml
+++ b/.github/workflows/test-action-build-html.yml
@@ -156,3 +156,45 @@ jobs:
 
           # ensure that the html directory is not present in the downloaded artifact
           test ! -d "${{ steps.simple4-artifact.outputs.download-path }}/html"
+
+      - name: Simple 5 invoke - with copy, with artifact, trailing slash in input
+        id: simple5
+        uses: ./actions/ansible-docs-build-html
+        with:
+          build-script: .test/simple-build/build.sh
+          build-html: .test/simple-build/build/html/
+          copy-build: .copies/simple5/html/
+          artifact-retention-days: 1
+          artifact-name: tests-simple5
+
+      - name: Simple 5 - Download artifacts
+        uses: actions/download-artifact@v2
+        id: simple5-artifact
+        with:
+          name: ${{ steps.simple5.outputs.artifact-name }}
+          path: .artifacts/simple5
+
+      - name: Simple 5 - assert
+        shell: python
+        run: |
+          expected_hash = r'${{ hashFiles('.test/simple-build/src') }}'
+          output_hash = r'${{ steps.simple5.outputs.hash }}'
+          output_build_html = r'${{ steps.simple5.outputs.build-html }}'
+          artifact_hash = r'${{ hashFiles(steps.simple5-artifact.outputs.download-path) }}'
+          original_build_hash = r'${{ hashFiles('.test/simple-build/build/html') }}'
+
+          assert output_build_html == '.copies/simple5/html'
+          assert output_hash == expected_hash
+          assert output_hash == original_build_hash
+          assert artifact_hash == output_hash
+
+      - name: Simple 5 - bash asserts
+        run: |
+          set -eu
+
+          # this URL only goes to the run page, not to an individual artifact
+          # so all we're really checking here is that it's a valid URL that's accessible
+          wget '${{ steps.simple5.outputs.artifact-url }}'
+
+          # ensure that the html directory is not present in the downloaded artifact
+          test ! -d "${{ steps.simple5-artifact.outputs.download-path }}/html"

--- a/.github/workflows/test-action-build-html.yml
+++ b/.github/workflows/test-action-build-html.yml
@@ -181,9 +181,9 @@ jobs:
           output_hash = r'${{ steps.simple5.outputs.hash }}'
           output_build_html = r'${{ steps.simple5.outputs.build-html }}'
           artifact_hash = r'${{ hashFiles(steps.simple5-artifact.outputs.download-path) }}'
-          original_build_hash = r'${{ hashFiles('.test/simple-build/build/html') }}'
+          original_build_hash = r'${{ hashFiles('.test/simple-build/build/html/') }}'
 
-          assert output_build_html == '.copies/simple5/html'
+          assert output_build_html == '.copies/simple5/html/'
           assert output_hash == expected_hash
           assert output_hash == original_build_hash
           assert artifact_hash == output_hash

--- a/.github/workflows/test-action-build-html.yml
+++ b/.github/workflows/test-action-build-html.yml
@@ -104,10 +104,16 @@ jobs:
           assert output_hash == expected_hash
           assert artifact_hash == output_hash
 
-      - name: Simple 3 - assert artifact url
-        # this URL only goes to the run page, not to an individual artifact
-        # so all we're really checking here is that it's a valid URL that's accessible
-        run: wget '${{ steps.simple3.outputs.artifact-url }}'
+      - name: Simple 3 - bash asserts
+        run: |
+          set -eu
+
+          # this URL only goes to the run page, not to an individual artifact
+          # so all we're really checking here is that it's a valid URL that's accessible
+          wget '${{ steps.simple3.outputs.artifact-url }}'
+
+          # ensure that the html directory is not present in the downloaded artifact
+          test ! -d "${{ steps.simple3-artifact.outputs.download-path }}/html"
 
       - name: Simple 4 invoke - with copy, with artifact
         id: simple4
@@ -140,7 +146,13 @@ jobs:
           assert output_hash == original_build_hash
           assert artifact_hash == output_hash
 
-      - name: Simple 4 - assert artifact url
-        # this URL only goes to the run page, not to an individual artifact
-        # so all we're really checking here is that it's a valid URL that's accessible
-        run: wget '${{ steps.simple4.outputs.artifact-url }}'
+      - name: Simple 4 - bash asserts
+        run: |
+          set -eu
+
+          # this URL only goes to the run page, not to an individual artifact
+          # so all we're really checking here is that it's a valid URL that's accessible
+          wget '${{ steps.simple4.outputs.artifact-url }}'
+
+          # ensure that the html directory is not present in the downloaded artifact
+          test ! -d "${{ steps.simple4-artifact.outputs.download-path }}/html"

--- a/.github/workflows/test-action-build-init.yml
+++ b/.github/workflows/test-action-build-init.yml
@@ -5,12 +5,12 @@ on:
     paths:
       - .test/**
       - .github/workflows/test-action-build-init.yml
-      - actions/ansibe-docs-build-init/**
+      - actions/ansible-docs-build-init/**
   pull_request:
     paths:
       - .test/**
       - .github/workflows/test-action-build-init.yml
-      - actions/ansibe-docs-build-init/**
+      - actions/ansible-docs-build-init/**
 
 jobs:
   tests:

--- a/actions/ansible-docs-build-html/action.yml
+++ b/actions/ansible-docs-build-html/action.yml
@@ -69,7 +69,7 @@ runs:
       if: fromJSON(inputs.artifact-upload)
       uses: actions/upload-artifact@v2
       with:
-        path: ${{ steps.build.outputs.build-html }}/
+        path: ${{ steps.build.outputs.build-html }}
         name: ${{ inputs.artifact-name }}
         retention-days: ${{ fromJSON(inputs.artifact-retention-days) }}
 

--- a/actions/ansible-docs-build-html/action.yml
+++ b/actions/ansible-docs-build-html/action.yml
@@ -69,7 +69,7 @@ runs:
       if: fromJSON(inputs.artifact-upload)
       uses: actions/upload-artifact@v2
       with:
-        path: ${{ steps.build.outputs.build-html }}
+        path: ${{ steps.build.outputs.build-html }}/
         name: ${{ inputs.artifact-name }}
         retention-days: ${{ fromJSON(inputs.artifact-retention-days) }}
 

--- a/actions/ansible-docs-build-html/action.yml
+++ b/actions/ansible-docs-build-html/action.yml
@@ -58,7 +58,7 @@ runs:
         if [[ "$COPY_BUILD" != "" ]] ; then
             echo "::group::Copy the build files"
             mkdir -p "$COPY_BUILD"
-            rsync -avc --delete-after "$HTML" "$COPY_BUILD"
+            rsync -avc --delete-after "$HTML/" "$COPY_BUILD"
             echo "::set-output name=build-html::$COPY_BUILD"
             echo "::endgroup::"
         else

--- a/actions/ansible-docs-build-html/action.yml
+++ b/actions/ansible-docs-build-html/action.yml
@@ -58,7 +58,7 @@ runs:
         if [[ "$COPY_BUILD" != "" ]] ; then
             echo "::group::Copy the build files"
             mkdir -p "$COPY_BUILD"
-            rsync -avc --delete-after "$HTML/" "$COPY_BUILD"
+            rsync -avc --delete-after "$HTML/" "$COPY_BUILD/"
             echo "::set-output name=build-html::$COPY_BUILD"
             echo "::endgroup::"
         else


### PR DESCRIPTION
Fixes: #24 

- fix typos in workflow triggers that prevented tests running
- add trailing slash to `rsync` command for `copy-build` option
- add tests to ensure artifact does not contain additional directory
- add tests that add a trailing slash on inputs to ensure it adding it again to rsync doesn't break