### PR TITLE
Use stable-2.13 instead of milestone as default

### DIFF
--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -18,10 +18,10 @@ on:
         type: string
         default: '3.9'
       ansible-ref:
-        description: The ref from which to install ansible, for example "stable-2.12" or "milestone".
+        description: The ref from which to install ansible, for example "stable-2.13" or "milestone".
         required: false
         type: string
-        default: milestone
+        default: stable-2.13
       init-dest-dir:
         description: A directory relative to the checkout where the init process has already been run.
         required: false

--- a/.github/workflows/_shared-docs-build-push.yml
+++ b/.github/workflows/_shared-docs-build-push.yml
@@ -18,10 +18,10 @@ on:
         type: string
         default: '3.9'
       ansible-ref:
-        description: The ref from which to install ansible, for example "stable-2.12" or "milestone".
+        description: The ref from which to install ansible, for example "stable-2.13" or "milestone".
         required: false
         type: string
-        default: milestone
+        default: stable-2.13
       init-dest-dir:
         description: A directory relative to the checkout where the init process has already been run.
         required: false


### PR DESCRIPTION
At least until milestone has been advanced. That should fix the docs build issues due to the new ansible-doc parameter missing...