### PR TITLE
bump actions versions, cache pip

### DIFF
--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -144,7 +144,7 @@ jobs:
     steps:
       - name: Variable setup
         id: vars
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             const inputs = ${{ toJSON(inputs) }}

--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -189,15 +189,19 @@ jobs:
             }
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ inputs.python }}
+          cache: pip
+          cache-dependency-path: |
+            **/requirements*.txt
+            **/build.sh
 
       - name: Install Ansible
         run: pip install https://github.com/ansible/ansible/archive/${{ inputs.ansible-ref }}.tar.gz --disable-pip-version-check
 
       - name: Checkout BASE
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: ${{ steps.vars.outputs.checkout-path }}
@@ -223,7 +227,7 @@ jobs:
           artifact-upload: 'false'
 
       - name: Checkout HEAD
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # It would be better to use
           #

--- a/.github/workflows/_shared-docs-build-publish-surge.yml
+++ b/.github/workflows/_shared-docs-build-publish-surge.yml
@@ -27,12 +27,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: DEBUG
-        run: |
-          echo <<EOF
-          ${{ toJSON(inputs) }}
-          EOF
-
       - name: Check required
         if: inputs.action == 'publish' && inputs.artifact-name == ''
         run: |

--- a/.github/workflows/_shared-docs-build-publish-surge.yml
+++ b/.github/workflows/_shared-docs-build-publish-surge.yml
@@ -36,13 +36,13 @@ jobs:
       - name: Retrieve rendered docs
         if: inputs.action == 'publish'
         id: download
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.artifact-name }}
           path: html
 
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14
 

--- a/.github/workflows/_shared-docs-build-push.yml
+++ b/.github/workflows/_shared-docs-build-push.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Variable setup
         id: vars
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             const inputs = ${{ toJSON(inputs) }}
@@ -102,15 +102,19 @@ jobs:
             core.setOutput('skip-init', skipInit)
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ inputs.python }}
+          cache: pip
+          cache-dependency-path: |
+            **/requirements*.txt
+            **/build.sh
 
       - name: Install Ansible
         run: pip install https://github.com/ansible/ansible/archive/${{ inputs.ansible-ref }}.tar.gz --disable-pip-version-check
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{ steps.vars.outputs.checkout-path }}
 

--- a/.github/workflows/generate-wiki-docs.yml
+++ b/.github/workflows/generate-wiki-docs.yml
@@ -23,19 +23,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - if: fromJSON(env.SHOULD_RUN)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Checkout wiki
         if: fromJSON(env.SHOULD_RUN)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.repository }}.wiki
           path: ${{ env.WIKI }}
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         if: fromJSON(env.SHOULD_RUN)
         with:
           python-version: '3.9'
+          cache: pip
+          cache-dependency-path: |
+            **/requirements*.txt
+            **/build.sh
 
       - name: Install Ansible
         if: fromJSON(env.SHOULD_RUN)

--- a/.github/workflows/test-action-build-html.yml
+++ b/.github/workflows/test-action-build-html.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Simple 1 invoke - no copy, no artifact
         id: simple1
@@ -30,7 +30,7 @@ jobs:
           artifact-upload: false
 
       - name: Simple 1 - Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         id: simple1-artifact
         with:
           path: .artifacts/simple1
@@ -57,7 +57,7 @@ jobs:
           artifact-upload: false
 
       - name: Simple 2 - Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         id: simple2-artifact
         with:
           path: .artifacts/simple2
@@ -86,7 +86,7 @@ jobs:
           artifact-name: tests-simple3
 
       - name: Simple 3 - Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         id: simple3-artifact
         with:
           name: ${{ steps.simple3.outputs.artifact-name }}
@@ -126,7 +126,7 @@ jobs:
           artifact-name: tests-simple4
 
       - name: Simple 4 - Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         id: simple4-artifact
         with:
           name: ${{ steps.simple4.outputs.artifact-name }}
@@ -168,7 +168,7 @@ jobs:
           artifact-name: tests-simple5
 
       - name: Simple 5 - Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         id: simple5-artifact
         with:
           name: ${{ steps.simple5.outputs.artifact-name }}

--- a/.github/workflows/test-action-build-init.yml
+++ b/.github/workflows/test-action-build-init.yml
@@ -43,12 +43,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
+          cache: pip
+          cache-dependency-path: |
+            **/requirements*.txt
+            **/build.sh
 
       # if we pass an empty string to dest-dir, it will override the default.
       # we can't copy the default into the matrix because it uses a templating

--- a/actions/ansible-docs-build-comment/action.yml
+++ b/actions/ansible-docs-build-comment/action.yml
@@ -53,7 +53,7 @@ runs:
 
     - name: Determine actions
       id: vars
-      uses: actions/github-script@v5
+      uses: actions/github-script@v6
       with:
         script: |
           const inputs = ${{ toJSON(inputs )}}

--- a/actions/ansible-docs-build-comment/action.yml
+++ b/actions/ansible-docs-build-comment/action.yml
@@ -45,7 +45,7 @@ runs:
   steps:
     - name: Look for an existing comment
       id: fc
-      uses: peter-evans/find-comment@v1
+      uses: peter-evans/find-comment@v2
       with:
         issue-number: ${{ inputs.pr-number }}
         body-includes: ${{ inputs.body-includes }}
@@ -78,7 +78,7 @@ runs:
       if: >-
         steps.vars.outputs.action == 'remove'
         && steps.fc.outputs.comment-id
-      uses: actions/github-script@v5
+      uses: actions/github-script@v6
       with:
         script: |
           github.rest.issues.deleteComment({
@@ -90,7 +90,7 @@ runs:
     - name: Post or update comment
       id: comment
       if: steps.vars.outputs.action == 'update'
-      uses: peter-evans/create-or-update-comment@v1
+      uses: peter-evans/create-or-update-comment@v2
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         issue-number: ${{ inputs.pr-number }}

--- a/actions/ansible-docs-build-diff/action.yml
+++ b/actions/ansible-docs-build-diff/action.yml
@@ -88,10 +88,10 @@ runs:
         echo "::group::Deleting files from ${{ inputs.build-html-b }}"
         find "${{ inputs.build-html-b }}" \( -name '*.js' -or -name '*.inv' \) -delete -print
         echo "::endgroup::"
-        
+
     - name: Create diff
       id: diff
-      uses: actions/github-script@v5
+      uses: actions/github-script@v6
       with:
         script: |
           // attribution: https://stackoverflow.com/a/3561711/3905079

--- a/actions/ansible-docs-build-html/action.yml
+++ b/actions/ansible-docs-build-html/action.yml
@@ -67,7 +67,7 @@ runs:
 
     - name: Upload artifact
       if: fromJSON(inputs.artifact-upload)
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         path: ${{ steps.build.outputs.build-html }}
         name: ${{ inputs.artifact-name }}


### PR DESCRIPTION
Most of GutHub's actions have had a major version bump, primarily to bump their required version of Node, because the one being used is EoL soon.

This updates those versions in the composite actions and workflows.

The `setup-python` action also added cache support (before the major version bump). Enabling that too; it only caches the pip cache, not installed packages, so it won't save us from install time (Ansible itself being the major time taker there), only from download time, but that also means we will not ever end up with stale packages due to the cache.

We don't actually have a good set of files in this repo to hash as a cache key, but still I figure, can't hurt.

If this ends up worse for whatever reason, we can remove it.