### PR TITLE
disable python cache

### DIFF
--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -192,10 +192,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ inputs.python }}
-          cache: pip
-          cache-dependency-path: |
-            **/requirements*.txt
-            **/build.sh
 
       - name: Install Ansible
         run: pip install https://github.com/ansible/ansible/archive/${{ inputs.ansible-ref }}.tar.gz --disable-pip-version-check

--- a/.github/workflows/_shared-docs-build-push.yml
+++ b/.github/workflows/_shared-docs-build-push.yml
@@ -105,10 +105,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ inputs.python }}
-          cache: pip
-          cache-dependency-path: |
-            **/requirements*.txt
-            **/build.sh
 
       - name: Install Ansible
         run: pip install https://github.com/ansible/ansible/archive/${{ inputs.ansible-ref }}.tar.gz --disable-pip-version-check

--- a/.github/workflows/generate-wiki-docs.yml
+++ b/.github/workflows/generate-wiki-docs.yml
@@ -36,10 +36,6 @@ jobs:
         if: fromJSON(env.SHOULD_RUN)
         with:
           python-version: '3.9'
-          cache: pip
-          cache-dependency-path: |
-            **/requirements*.txt
-            **/build.sh
 
       - name: Install Ansible
         if: fromJSON(env.SHOULD_RUN)

--- a/.github/workflows/test-action-build-init.yml
+++ b/.github/workflows/test-action-build-init.yml
@@ -49,10 +49,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: 3.9
-          cache: pip
-          cache-dependency-path: |
-            **/requirements*.txt
-            **/build.sh
 
       # if we pass an empty string to dest-dir, it will override the default.
       # we can't copy the default into the matrix because it uses a templating


### PR DESCRIPTION
#32 added caching for setup-python, with the caveat that if it caused any problems we'd remove it: and it is breaking in PR workflow at least, because we set up python before checking out, so it can't find the cache key files.

I could consider tweaking the order of things, but I think it's better to remove caching for now and not consider re-adding until we have tests for the workflows (#29) , as the benefit was likely to be minimal anyway.