### PR TITLE
fix PR workflow checkouts

### DIFF
--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -175,14 +175,17 @@ jobs:
 
             core.setOutput('skip-init', skipInit)
 
-            // when a PR is first opened, the merge sha is blank
-            // when a PR is closed, the merge branch doesn't exist
-            // so let's set a var for the PR ref we'll checkout,
-            // using the merge SHA usually, but using the merge branch
-            // if the SHA is blank.
+            // The merge branch is what we want, but it doesn't exist
+            // on closed events. The merge SHA does exist though and
+            // should be correct. The merge SHA does not exist when a
+            // PR is first opened, and on subsequent updates it is
+            // tricky to use; used directly it is probably stale, and
+            // would need additional API calls to get the correct value.
+            // See also:
+            // - https://github.com/ansible-community/github-docs-build/issues/36
 
             const mergeSha = '${{ github.event.pull_request.merge_commit_sha }}'
-            if (mergeSha != '') {
+            if ('${{ github.event.action }}' == 'closed') {
                 core.setOutput('pr-checkout-ref', mergeSha)
             } else {
                 core.setOutput('pr-checkout-ref', 'refs/pull/${{ github.event.number }}/merge')

--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -184,7 +184,6 @@ jobs:
             // See also:
             // - https://github.com/ansible-community/github-docs-build/issues/36
 
-            const mergeSha = '${{ github.event.pull_request.merge_commit_sha }}'
             if ('${{ github.event.action }}' == 'closed') {
                 core.setOutput('pr-checkout-ref', '${{ github.event.pull_request.merge_commit_sha }}')
             } else {

--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -186,7 +186,7 @@ jobs:
 
             const mergeSha = '${{ github.event.pull_request.merge_commit_sha }}'
             if ('${{ github.event.action }}' == 'closed') {
-                core.setOutput('pr-checkout-ref', mergeSha)
+                core.setOutput('pr-checkout-ref', '${{ github.event.pull_request.merge_commit_sha }}')
             } else {
                 core.setOutput('pr-checkout-ref', 'refs/pull/${{ github.event.number }}/merge')
             }


### PR DESCRIPTION
Resolves #36 

Changing to use the merge branch in all cases except on PR close where it's not available.

After thinking through this, I think this is the best change to make, at least in the short term:
- the current situation is plain broken most of the time
- I don't think re-runs are a significant enough issue to worry about them for the most part; I can't think of a good use case for re-running against an old commit and expecting results consistent with the state of the PR and the target at the time of the original run (I don't think we were addressing this anyway).
- Although we're not comparing against the point where the PR branched from the target branch necessarily, I think the merge branch is better for what we're trying to achieve, which is seeing what the end result will be (this is not different than the current sate either).

Tests:
- https://github.com/briantist/gha-junk/pull/6

While I did not end-to-end test that the checkout and contents were correct, I checked that the change did not break on any of the PR actions, and that the expected checkout ref was set. That is enough for me to be confident the change.