### PR TITLE
Upload generated RST files after docs-build

### DIFF
--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -47,6 +47,11 @@ on:
         required: false
         type: string
         default: ${{ github.event.repository.name }}_docs_${{ github.event.pull_request.head.sha }}
+      rst-artifact-name:
+        description: The name of the RST artifact to upload.
+        required: false
+        type: string
+        default: ${{ github.event.repository.name }}_rst_${{ github.event.pull_request.head.sha }}
       diff-size-limit:
         description: The max size of the diff, past which it will be truncated.
         required: false
@@ -223,6 +228,7 @@ jobs:
           build-html: ${{ steps.init-base.outputs.build-html }}
           copy-build: ${{ github.workspace }}/docsbuild/base
           artifact-upload: 'false'
+          rst-artifact-upload: 'false'
 
       - name: Checkout HEAD
         uses: actions/checkout@v3
@@ -253,8 +259,11 @@ jobs:
         with:
           build-script: ${{ steps.init-head.outputs.build-script }}
           build-html: ${{ steps.init-head.outputs.build-html }}
+          build-rst: ${{ steps.init-head.outputs.build-rst }}
           copy-build: ${{ github.workspace }}/docsbuild/head
+          copy-rst: ${{ github.workspace }}/rst
           artifact-name: ${{ inputs.artifact-name }}
+          rst-artifact-name: ${{ inputs.rst-artifact-name }}
 
       - name: Get a diff of the changes
         if: steps.build-base.outputs.hash != steps.build-head.outputs.hash

--- a/actions/ansible-docs-build-html/action.yml
+++ b/actions/ansible-docs-build-html/action.yml
@@ -10,9 +10,19 @@ inputs:
     description: The path where the build script will output the HTML.
     required: false
     default: ${{ runner.temp }}/docsbuild/build/html
+  build-rst:
+    description: The path where the build script will output the RST.
+    required: false
+    default: ${{ runner.temp }}/docsbuild/rst
   copy-build:
     description: |
       If set, copy the built HTML files to this path after building, and set the build-html output to this path instead.
+      This is useful if you need to do multiple builds from the same environment, or otherwise need the files to be elsewhere.
+      Note: files in the destination that do not exist in the source will be deleted!
+    required: false
+  copy-rst:
+    description: |
+      If set, copy the preprocessed RST files to this path after building, and set the build-rst output to this path instead.
       This is useful if you need to do multiple builds from the same environment, or otherwise need the files to be elsewhere.
       Note: files in the destination that do not exist in the source will be deleted!
     required: false
@@ -20,10 +30,18 @@ inputs:
     description: If true then upload the rendered docs as a build artifact.
     required: false
     default: 'true'
+  rst-artifact-upload:
+    description: If true then upload the rendered docs as a build artifact.
+    required: false
+    default: 'true'
   artifact-name:
     description: The name of the build artifact.
     required: false
     default: ${{ github.event.repository.name }}_docs
+  rst-artifact-name:
+    description: The name of the RST artifact.
+    required: false
+    default: ${{ github.event.repository.name }}_rst
   artifact-retention-days:
     description: Number of days to keep the artifact.
     required: false
@@ -53,7 +71,9 @@ runs:
         echo "::endgroup::"
 
         HTML="${{ inputs.build-html }}"
+        RST="${{ inputs.build-rst }}"
         COPY_BUILD="${{ inputs.copy-build }}"
+        COPY_RST="${{ inputs.copy-rst }}"
 
         if [[ "$COPY_BUILD" != "" ]] ; then
             echo "::group::Copy the build files"
@@ -65,12 +85,30 @@ runs:
             echo "::set-output name=build-html::$HTML"
         fi
 
-    - name: Upload artifact
+        if [[ "$COPY_RST" != "" ]] ; then
+            echo "::group::Copy the pre-processed files"
+            mkdir -p "$COPY_RST"
+            rsync -avc --delete-after "$RST/" "$COPY_RST/"
+            echo "::set-output name=build-rst::$COPY_RST"
+            echo "::endgroup::"
+        else
+            echo "::set-output name=build-rst::$RST"
+        fi
+
+    - name: Upload HTML artifact
       if: fromJSON(inputs.artifact-upload)
       uses: actions/upload-artifact@v3
       with:
         path: ${{ steps.build.outputs.build-html }}
         name: ${{ inputs.artifact-name }}
+        retention-days: ${{ fromJSON(inputs.artifact-retention-days) }}
+
+    - name: Upload RST artifact
+      if: fromJSON(inputs.rst-artifact-upload)
+      uses: actions/upload-artifact@v3
+      with:
+        path: ${{ steps.build.outputs.build-rst }}
+        name: ${{ inputs.rst-artifact-name }}
         retention-days: ${{ fromJSON(inputs.artifact-retention-days) }}
 
     - name: Output step

--- a/actions/ansible-docs-build-init/action.yml
+++ b/actions/ansible-docs-build-init/action.yml
@@ -43,6 +43,9 @@ outputs:
   build-html:
     description: The path of the build's html output directory.
     value: ${{ steps.init.outputs.build-html }}
+  build-rst:
+    description: The path of the build's RST output directory.
+    value: ${{ steps.init.outputs.build-rst }}
 
 runs:
   using: composite
@@ -77,4 +80,5 @@ runs:
         echo "::endgroup::"
 
         echo "::set-output name=build-script::${{ inputs.dest-dir }}/build.sh"
+        echo "::set-output name=build-rst::${{ inputs.dest-dir }}/rst"
         echo "::set-output name=build-html::${{ inputs.dest-dir }}/build/html"


### PR DESCRIPTION
Because the RST files are regenerated from modules the line numbers can be misleading.  Upload a separate artefact bundle with the generated RST files.