### PR TITLE
Support installing extra collections

### DIFF
--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -96,6 +96,10 @@ on:
           ```
 
           </details>
+      extra-collections:
+        description: A space separated list of additional collections to install prior to building the documentation.
+        required: false
+        type: string
 
     outputs:
       artifact-name:
@@ -197,6 +201,13 @@ jobs:
 
       - name: Install Ansible
         run: pip install https://github.com/ansible/ansible/archive/${{ inputs.ansible-ref }}.tar.gz --disable-pip-version-check
+
+      - name: Install extra collections
+        shell: bash
+        run: |
+          if [[ "${{ inputs.extra-collections }}" != "" ]] ; then
+            ansible-galaxy collection install ${{ inputs.extra-collections }}
+          fi
 
       - name: Checkout BASE
         uses: actions/checkout@v3

--- a/.github/workflows/_shared-docs-build-push.yml
+++ b/.github/workflows/_shared-docs-build-push.yml
@@ -47,6 +47,10 @@ on:
         required: false
         type: string
         default: ${{ github.event.repository.name }}_docs_${{ github.sha }}
+      extra-collections:
+        description: A space separated list of additional collections to install prior to building the documentation.
+        required: false
+        type: string
 
     outputs:
       artifact-name:
@@ -108,6 +112,13 @@ jobs:
 
       - name: Install Ansible
         run: pip install https://github.com/ansible/ansible/archive/${{ inputs.ansible-ref }}.tar.gz --disable-pip-version-check
+
+      - name: Install extra collections
+        shell: bash
+        run: |
+          if [[ "${{ inputs.extra-collections }}" != "" ]] ; then
+            ansible-galaxy collection install ${{ inputs.extra-collections }}
+          fi
 
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
The community.aws collection relies on a documentation fragment from amazon.aws.

In an ideal world this could be cloned from the same branch that the PR's against (eg `stable-3` of amazon.aws and `stable-3` of community.aws), however, this is a reasonable first approximation.

fixes: #40 