### PR TITLE
Allow to provide extra labels

### DIFF
--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -100,6 +100,10 @@ on:
         description: A space separated list of additional collections to install prior to building the documentation.
         required: false
         type: string
+      provide-link-targets:
+        description: A comma separated list of link targets that should not cause reference errors. A small RST file will be created during the build which contains these labels.
+        required: false
+        type: string
 
     outputs:
       artifact-name:
@@ -225,6 +229,7 @@ jobs:
           antsibull-docs-version: '${{ inputs.init-antsibull-docs-version }}'
           lenient: ${{ inputs.init-lenient }}
           fail-on-error: ${{ inputs.init-fail-on-error }}
+          provide-link-targets: ${{ inputs.provide-link-targets }}
 
       - name: Build BASE
         id: build-base
@@ -257,6 +262,7 @@ jobs:
           antsibull-docs-version: '${{ inputs.init-antsibull-docs-version }}'
           lenient: ${{ inputs.init-lenient }}
           fail-on-error: ${{ inputs.init-fail-on-error }}
+          provide-link-targets: ${{ inputs.provide-link-targets }}
 
       - name: Build HEAD
         id: build-head

--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -101,7 +101,7 @@ on:
         required: false
         type: string
       provide-link-targets:
-        description: A comma separated list of link targets that should not cause reference errors. A small RST file will be created during the build which contains these labels.
+        description: A newline separated list of link targets that should not cause reference errors. A small RST file will be created during the build which contains these labels.
         required: false
         type: string
 

--- a/.github/workflows/test-action-build-init.yml
+++ b/.github/workflows/test-action-build-init.yml
@@ -35,11 +35,16 @@ jobs:
         fail-on-error:
           - true
           - false
+        provide-links-safely:
+          - |
+            outside_reference_1
+            outside_reference_2
         include:
           - skip-init: true
             dest: .test/simple-build
             lenient: false  # unused but needs a value
             fail-on-error: false  # unused but needs a value
+            provide-links-safely: ''
 
     steps:
       - name: Checkout
@@ -66,6 +71,7 @@ jobs:
           skip-init: ${{ matrix.skip-init }}
           antsibull-docs-version: ${{ matrix.antsibull-docs-version }}
           lenient: ${{ matrix.lenient }}
+          provide-links-safely: ${{ matrix.provide-links-safely }}
 
       - name: assert
         env:
@@ -102,3 +108,10 @@ jobs:
           # if fail-on-error == 'false', the grep should succeed (!fail) and never run the false command
           # short circuit if skip-init is 'true'
           ${{ matrix.skip-init }} || ! grep -- '--fail-on-error' conf.py || ${{ matrix.fail-on-error }} || exit 1
+
+          # check if provide-links-safely was used
+          # :orphan: and the labels mentioned in provide-links-safely should end up in rst/_targets.rst
+          # short circuit if skip-init is 'true'
+          ${{ matrix.skip-init }} || grep -- '^:orphan:$' rst/_targets.rst || exit 1
+          ${{ matrix.skip-init }} || grep -- '^.. _outside_reference_1:$' rst/_targets.rst || exit 1
+          ${{ matrix.skip-init }} || grep -- '^.. _outside_reference_2:$' rst/_targets.rst || exit 1

--- a/.github/workflows/test-action-build-init.yml
+++ b/.github/workflows/test-action-build-init.yml
@@ -71,7 +71,7 @@ jobs:
           skip-init: ${{ matrix.skip-init }}
           antsibull-docs-version: ${{ matrix.antsibull-docs-version }}
           lenient: ${{ matrix.lenient }}
-          provide-links-safely: ${{ matrix.provide-links-safely }}
+          provide-link-targets: ${{ matrix.provide-links-safely }}
 
       - name: assert
         env:

--- a/.github/workflows/test-action-build-init.yml
+++ b/.github/workflows/test-action-build-init.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   tests:
-    name: Init [ver=${{ matrix.antsibull-docs-version }}, skip=${{ matrix.skip-init }}, lenient=${{ matrix.lenient }}, fail-on-error=${{ matrix.fail-on-error }}, dest=${{ matrix.dest }}, collections=${{ matrix.collections }}]
+    name: Init [ver=${{ matrix.antsibull-docs-version }}, skip=${{ matrix.skip-init }}, lenient=${{ matrix.lenient }}, fail-on-error=${{ matrix.fail-on-error }}, dest=${{ matrix.dest }}, collections=${{ matrix.collections }}, provide-link-targets=${{ matrix.provide-link-targets }}]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -36,6 +36,7 @@ jobs:
           - true
           - false
         provide-link-targets:
+          - ''
           - |
             outside_reference_1
             outside_reference_2
@@ -109,9 +110,13 @@ jobs:
           # short circuit if skip-init is 'true'
           ${{ matrix.skip-init }} || ! grep -- '--fail-on-error' conf.py || ${{ matrix.fail-on-error }} || exit 1
 
-          # check if provide-link-targets was used
+          # check if provide-link-targets was used (being no empty)
           # :orphan: and the labels mentioned in provide-link-targets should end up in rst/_targets.rst
-          # short circuit if skip-init is 'true'
-          ${{ matrix.skip-init }} || grep -- '^:orphan:$' rst/_targets.rst || exit 1
-          ${{ matrix.skip-init }} || grep -- '^.. _outside_reference_1:$' rst/_targets.rst || exit 1
-          ${{ matrix.skip-init }} || grep -- '^.. _outside_reference_2:$' rst/_targets.rst || exit 1
+          # short circuit if skip-init is 'true' or matrix.provide-link-targets is empty
+          ${{ matrix.skip-init }} || ${{ matrix.provide-link-targets == '' }} || grep -- '^:orphan:$' rst/_targets.rst || exit 1
+          ${{ matrix.skip-init }} || ${{ matrix.provide-link-targets == '' }} || grep -- '^.. _outside_reference_1:$' rst/_targets.rst || exit 1
+          ${{ matrix.skip-init }} || ${{ matrix.provide-link-targets == '' }} || grep -- '^.. _outside_reference_2:$' rst/_targets.rst || exit 1
+
+          # check if provide-link-targets was not used when being empty
+          # short circuit if skip-init is 'true' or matrix.provide-link-targets is not empty
+          ${{ matrix.skip-init }} || ${{ matrix.provide-link-targets != '' }} || ! test -e rst/_targets.rst || exit 1

--- a/.github/workflows/test-action-build-init.yml
+++ b/.github/workflows/test-action-build-init.yml
@@ -35,7 +35,7 @@ jobs:
         fail-on-error:
           - true
           - false
-        provide-links-safely:
+        provide-link-targets:
           - |
             outside_reference_1
             outside_reference_2
@@ -44,7 +44,7 @@ jobs:
             dest: .test/simple-build
             lenient: false  # unused but needs a value
             fail-on-error: false  # unused but needs a value
-            provide-links-safely: ''
+            provide-link-targets: ''
 
     steps:
       - name: Checkout
@@ -71,7 +71,7 @@ jobs:
           skip-init: ${{ matrix.skip-init }}
           antsibull-docs-version: ${{ matrix.antsibull-docs-version }}
           lenient: ${{ matrix.lenient }}
-          provide-link-targets: ${{ matrix.provide-links-safely }}
+          provide-link-targets: ${{ matrix.provide-link-targets }}
 
       - name: assert
         env:
@@ -109,8 +109,8 @@ jobs:
           # short circuit if skip-init is 'true'
           ${{ matrix.skip-init }} || ! grep -- '--fail-on-error' conf.py || ${{ matrix.fail-on-error }} || exit 1
 
-          # check if provide-links-safely was used
-          # :orphan: and the labels mentioned in provide-links-safely should end up in rst/_targets.rst
+          # check if provide-link-targets was used
+          # :orphan: and the labels mentioned in provide-link-targets should end up in rst/_targets.rst
           # short circuit if skip-init is 'true'
           ${{ matrix.skip-init }} || grep -- '^:orphan:$' rst/_targets.rst || exit 1
           ${{ matrix.skip-init }} || grep -- '^.. _outside_reference_1:$' rst/_targets.rst || exit 1

--- a/.github/workflows/test-action-build-init.yml
+++ b/.github/workflows/test-action-build-init.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   tests:
-    name: Init [ver=${{ matrix.antsibull-docs-version }}, skip=${{ matrix.skip-init }}, lenient=${{ matrix.lenient }}, fail-on-error=${{ matrix.fail-on-error }}, dest=${{ matrix.dest }}, collections=${{ matrix.collections }}, provide-link-targets=${{ matrix.provide-link-targets }}]
+    name: Init [ver=${{ matrix.antsibull-docs-version }}, skip=${{ matrix.skip-init }}, lenient=${{ matrix.lenient }}, fail-on-error=${{ matrix.fail-on-error }}, dest=${{ matrix.dest }}, collections=${{ matrix.collections }}, link-targets=${{ matrix.provide-link-targets != '' }}]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/actions/ansible-docs-build-init/action.yml
+++ b/actions/ansible-docs-build-init/action.yml
@@ -36,6 +36,10 @@ inputs:
       The version of antsibull-docs to install. When set, it refers to a git ref from which to install.
       If not set, the latest version from PyPI is installed.
     required: false
+  provide-link-targets:
+    description: A comma separated list of link targets that should not cause reference errors. A small RST file will be created during the build which contains these labels.
+    required: false
+    type: string
 outputs:
   build-script:
     description: The path of the build script to execute.
@@ -69,6 +73,17 @@ runs:
 
             echo "::group::Initialize Sphinx"
             antsibull-docs sphinx-init --use-current ${{ fromJSON(inputs.fail-on-error) && '--fail-on-error' || '' }} ${{ fromJSON(inputs.lenient) && '--lenient' || '' }} --dest-dir "${{ inputs.dest-dir }}" ${{ inputs.collections }}
+            echo "::endgroup::"
+        fi
+
+        if [[ "${{ inputs.provide-link-targets }}" != "" ]]; then
+            echo "::group::Create small RST file for link"
+            mkdir -p "${{ inputs.dest-dir }}/rst"
+            echo ":orphan:" > "${{ inputs.dest-dir }}/rst/_targets.rst"
+            while read -r line; do
+              echo ".. _${line}:" >> "${{ inputs.dest-dir }}/rst/_targets.rst"
+            done <<< "$(tr ',' '\n' <<< "${{ inputs.provide-link-targets }}")"
+            echo "This file just exists to provide link targets. Please ignore it." >> "${{ inputs.dest-dir }}/rst/_targets.rst"
             echo "::endgroup::"
         fi
 

--- a/actions/ansible-docs-build-init/action.yml
+++ b/actions/ansible-docs-build-init/action.yml
@@ -55,6 +55,7 @@ runs:
       id: init
       env:
         PIP_DISABLE_PIP_VERSION_CHECK: '1'
+        _INPUT_PROVIDE_LINK_TARGETS: ${{ inputs.provide-link-targets }}
       shell: bash
       run: |
         echo "::group::Installing antsibull-docs"
@@ -76,13 +77,13 @@ runs:
             echo "::endgroup::"
         fi
 
-        if [[ "${{ inputs.provide-link-targets }}" != "" ]]; then
+        if [[ "${_INPUT_PROVIDE_LINK_TARGETS}" != "" ]]; then
             echo "::group::Create small RST file for link"
             mkdir -p "${{ inputs.dest-dir }}/rst"
             echo ":orphan:" > "${{ inputs.dest-dir }}/rst/_targets.rst"
             while read -r line; do
               echo ".. _${line}:" >> "${{ inputs.dest-dir }}/rst/_targets.rst"
-            done <<< "${{ inputs.provide-link-targets }}"
+            done <<< "${_INPUT_PROVIDE_LINK_TARGETS}"
             echo "This file just exists to provide link targets. Please ignore it." >> "${{ inputs.dest-dir }}/rst/_targets.rst"
             echo "::endgroup::"
         fi

--- a/actions/ansible-docs-build-init/action.yml
+++ b/actions/ansible-docs-build-init/action.yml
@@ -37,7 +37,7 @@ inputs:
       If not set, the latest version from PyPI is installed.
     required: false
   provide-link-targets:
-    description: A comma separated list of link targets that should not cause reference errors. A small RST file will be created during the build which contains these labels.
+    description: A newline separated list of link targets that should not cause reference errors. A small RST file will be created during the build which contains these labels.
     required: false
     type: string
 outputs:
@@ -82,7 +82,7 @@ runs:
             echo ":orphan:" > "${{ inputs.dest-dir }}/rst/_targets.rst"
             while read -r line; do
               echo ".. _${line}:" >> "${{ inputs.dest-dir }}/rst/_targets.rst"
-            done <<< "$(tr ',' '\n' <<< "${{ inputs.provide-link-targets }}")"
+            done <<< "${{ inputs.provide-link-targets }}"
             echo "This file just exists to provide link targets. Please ignore it." >> "${{ inputs.dest-dir }}/rst/_targets.rst"
             echo "::endgroup::"
         fi


### PR DESCRIPTION
Sometimes you don't want to add extra collections to the docs build to resolve some labels, but just provide these label targets. This is useful for community.general which has redirects to infoblox.nios_modules, but we don't want to install that collection to build the docs (it's not under our control and might produce new build errors). Building without that collection gives warnings such as
```
.../rst/collections/community/general/nios_a_record_module.rst:21: WARNING: undefined label: ansible_collections.infoblox.nios_modules.nios_a_record_module
```
which would require us to be lenient on docs build errors. With this new option we can add a file (rst/_targets.rst) that contains the given labels.

(Not yet tested.)