### PR TITLE
first pass at a GitHub Pages publishing shared workflow

### DIFF
--- a/.github/workflows/_shared-docs-build-publish-gh-pages.yml
+++ b/.github/workflows/_shared-docs-build-publish-gh-pages.yml
@@ -97,4 +97,4 @@ jobs:
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           publish_dir: html
-          destination-dir: ${{ steps.vars.outputs.dest }}
+          destination_dir: ${{ steps.vars.outputs.dest }}

--- a/.github/workflows/_shared-docs-build-publish-gh-pages.yml
+++ b/.github/workflows/_shared-docs-build-publish-gh-pages.yml
@@ -13,11 +13,6 @@ on:
           If not given, the destination will be calculated based on what triggered the event.
         required: false
         type: string
-
-    #   surge-site-name:
-    #     description: The full surge site domain to publish or teardown.
-    #     required: true
-    #     type: string
       action:
         description: Action to perform. 'publish' to publish the site, 'teardown' to tear it down.
         required: false
@@ -25,12 +20,12 @@ on:
         type: string
       base-url:
         description: |
-          The base URL of the published site, ending with a forward slash '/'.
+          The base URL of the published site. Do not include a trailing forward slash '/'.
           This is not used for the publishing process, but the resulting destination dir will be concatenated to it,
           and then returned in the workflow's outputs.
         required: false
         type: string
-        default: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/
+        default: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
     outputs:
       url:
         description: The destination path. If base-url was provided, it will be pre-pended.

--- a/.github/workflows/_shared-docs-build-publish-gh-pages.yml
+++ b/.github/workflows/_shared-docs-build-publish-gh-pages.yml
@@ -10,7 +10,10 @@ on:
       destination-dir:
         description: |
           The destination path within the published site. Should not start with a forward slash '/'.
-          If not given, the destination will be calculated based on what triggered the event.
+          If not given, the destination will be calculated based on what triggered the event:
+          - pull - pr/<pr #>
+          - push (branch) - branch/<branch name>
+          - push (tag) - tag/<tag name>
         required: false
         type: string
       action:
@@ -28,13 +31,13 @@ on:
         default: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
     outputs:
       url:
-        description: The destination path. If base-url was provided, it will be pre-pended.
+        description: The destination path pre-pended with the base-url.
         value: ${{ jobs.publish-gh-pages.outputs.url }}
     secrets:
       GH_TOKEN:
         description: |
           The token used for publishing to GitHub Pages.
-          Even when using the workflow token, it must be passed explicitly.
+          Even when using the workflow token (secrets.GITHUB_TOKEN), it must be passed explicitly.
         required: true
 jobs:
   publish-gh-pages:
@@ -82,7 +85,7 @@ jobs:
           name: ${{ inputs.artifact-name }}
           path: html
 
-      - name: Teardown
+      - name: Teardown source
         if: inputs.action == 'teardown'
         run: mkdir -p html
 
@@ -94,4 +97,8 @@ jobs:
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           publish_dir: html
+          keep_files: false  # with destination_dir, this applies only to the chosen dir
           destination_dir: ${{ steps.vars.outputs.dest }}
+          # NOTE: do not use the force_orphan (keep_history) option.
+          # It does not yet work correctly with keep_files and destination_dir:
+          # - https://github.com/peaceiris/actions-gh-pages/issues/455

--- a/.github/workflows/_shared-docs-build-publish-gh-pages.yml
+++ b/.github/workflows/_shared-docs-build-publish-gh-pages.yml
@@ -25,7 +25,7 @@ on:
         type: string
       base-url:
         description: |
-          The base URL of the published site, ending with a forward slash '/'.'
+          The base URL of the published site, ending with a forward slash '/'.
           This is not used for the publishing process, but the resulting destination dir will be concatenated to it,
           and then returned in the workflow's outputs.
         required: false

--- a/.github/workflows/_shared-docs-build-publish-gh-pages.yml
+++ b/.github/workflows/_shared-docs-build-publish-gh-pages.yml
@@ -62,7 +62,7 @@ jobs:
             if (destination_dir == '') {
                 const gh = ${{ toJSON(github) }}
 
-                if (gh['event_name'] == 'pull_request') {
+                if (gh['event_name'].startsWith('pull_request')) {
                     destination_dir = `pr/${gh['event']['number']}`
                 }
                 else {

--- a/.github/workflows/_shared-docs-build-publish-gh-pages.yml
+++ b/.github/workflows/_shared-docs-build-publish-gh-pages.yml
@@ -30,7 +30,7 @@ on:
           and then returned in the workflow's outputs.
         required: false
         type: string
-        default: ''
+        default: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/
     outputs:
       url:
         description: The destination path. If base-url was provided, it will be pre-pended.
@@ -39,7 +39,7 @@ on:
       GH_TOKEN:
         description: |
           The token used for publishing to GitHub Pages.
-          Even when using the workflow secret, it must be passed explicitly.
+          Even when using the workflow token, it must be passed explicitly.
         required: true
 jobs:
   publish-gh-pages:

--- a/.github/workflows/_shared-docs-build-publish-gh-pages.yml
+++ b/.github/workflows/_shared-docs-build-publish-gh-pages.yml
@@ -1,5 +1,5 @@
 ---
-name: Ansible collection docs - publish to Surge
+name: Ansible collection docs - publish to GitHub Pages
 on:
   workflow_call:
     inputs:
@@ -7,26 +7,70 @@ on:
         description: The build artifact that contains the rendered HTML. Required when action == 'publish'
         required: false
         type: string
-      surge-site-name:
-        description: The full surge site domain to publish or teardown.
-        required: true
+      destination-dir:
+        description: |
+          The destination path within the published site. Should not start with a forward slash '/'.
+          If not given, the destination will be calculated based on what triggered the event.
+        required: false
         type: string
+
+    #   surge-site-name:
+    #     description: The full surge site domain to publish or teardown.
+    #     required: true
+    #     type: string
       action:
         description: Action to perform. 'publish' to publish the site, 'teardown' to tear it down.
         required: false
         default: 'publish'
         type: string
+      base-url:
+        description: |
+          The base URL of the published site, ending with a forward slash '/'.'
+          This is not used for the publishing process, but the resulting destination dir will be concatenated to it,
+          and then returned in the workflow's outputs.
+        required: false
+        type: string
+        default: ''
+    outputs:
+      url:
+        description: The destination path. If base-url was provided, it will be pre-pended.
+        value: ${{ steps.vars.outputs.url }}
     secrets:
-      SURGE_TOKEN:
-        description: The token used for publishing to surge.
+      github_token:
+        description: |
+          The token used for publishing to GitHub Pages.
+          Even when using the workflow secret, it must be passed explicitly.
         required: true
 jobs:
   publish-gh-pages:
-    name: Publish to Surge.sh
+    name: Publish to GitHub Pages
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
+      - name: Process variables
+        id: vars
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const inputs = ${{ toJSON(inputs) }}
+            var destination_dir = inputs['destination-dir']
+            var base_url = inputs['base-url']
+
+            if (destination_dir == '') {
+                const gh = ${{ toJSON(github) }}
+
+                if (gh['event_name'] == 'pull_request') {
+                    destination_dir = `pr/${gh['event']['number']}`
+                }
+                else {
+                    destination_dir = `${gh['ref_type']}/${gh['ref_name']}`
+                }
+            }
+
+            core.setOutput('dest', destination_dir)
+            core.setOutput('url', `${base_url}/${destination_dir}`)
+
       - name: Check required
         if: inputs.action == 'publish' && inputs.artifact-name == ''
         run: |
@@ -41,20 +85,14 @@ jobs:
           name: ${{ inputs.artifact-name }}
           path: html
 
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 14
-
-      - name: Install Surge
-        run: npm install -g surge@0.23.1
-
-      - name: Publish site
-        if: inputs.action == 'publish'
-        working-directory: html
-        run: surge ./ "${{ inputs.surge-site-name }}" --token ${{ secrets.SURGE_TOKEN }}
-
-      - name: Teardown site
+      - name: Teardown
         if: inputs.action == 'teardown'
-        run: surge teardown "${{ inputs.surge-site-name }}" --token ${{ secrets.SURGE_TOKEN }}
-        continue-on-error: true
+        run: mkdir -p html
+
+      - name: Publish
+        # if: inputs.action == 'publish'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.github_token }}
+          publish_dir: html
+          destination-dir: ${{ steps.vars.outputs.dest }}

--- a/.github/workflows/_shared-docs-build-publish-gh-pages.yml
+++ b/.github/workflows/_shared-docs-build-publish-gh-pages.yml
@@ -95,4 +95,3 @@ jobs:
           github_token: ${{ secrets.GH_TOKEN }}
           publish_dir: html
           destination_dir: ${{ steps.vars.outputs.dest }}
-          force_orphan: true

--- a/.github/workflows/_shared-docs-build-publish-gh-pages.yml
+++ b/.github/workflows/_shared-docs-build-publish-gh-pages.yml
@@ -21,7 +21,7 @@ on:
         description: The token used for publishing to surge.
         required: true
 jobs:
-  publish-surge:
+  publish-gh-pages:
     name: Publish to Surge.sh
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/_shared-docs-build-publish-gh-pages.yml
+++ b/.github/workflows/_shared-docs-build-publish-gh-pages.yml
@@ -46,7 +46,7 @@ jobs:
     name: Publish to GitHub Pages
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     outputs:
       url: ${{ steps.vars.outputs.url }}
     steps:

--- a/.github/workflows/_shared-docs-build-publish-gh-pages.yml
+++ b/.github/workflows/_shared-docs-build-publish-gh-pages.yml
@@ -36,7 +36,7 @@ on:
         description: The destination path. If base-url was provided, it will be pre-pended.
         value: ${{ steps.vars.outputs.url }}
     secrets:
-      github_token:
+      GH_TOKEN:
         description: |
           The token used for publishing to GitHub Pages.
           Even when using the workflow secret, it must be passed explicitly.
@@ -93,6 +93,6 @@ jobs:
         # if: inputs.action == 'publish'
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.GH_TOKEN }}
           publish_dir: html
           destination-dir: ${{ steps.vars.outputs.dest }}

--- a/.github/workflows/_shared-docs-build-publish-gh-pages.yml
+++ b/.github/workflows/_shared-docs-build-publish-gh-pages.yml
@@ -95,3 +95,4 @@ jobs:
           github_token: ${{ secrets.GH_TOKEN }}
           publish_dir: html
           destination_dir: ${{ steps.vars.outputs.dest }}
+          force_orphan: true

--- a/.github/workflows/_shared-docs-build-publish-gh-pages.yml
+++ b/.github/workflows/_shared-docs-build-publish-gh-pages.yml
@@ -34,7 +34,7 @@ on:
     outputs:
       url:
         description: The destination path. If base-url was provided, it will be pre-pended.
-        value: ${{ steps.vars.outputs.url }}
+        value: ${{ jobs.publish-gh-pages.outputs.url }}
     secrets:
       GH_TOKEN:
         description: |
@@ -47,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      url: ${{ steps.vars.outputs.url }}
     steps:
       - name: Process variables
         id: vars

--- a/.github/workflows/_shared-docs-build-publish-gh-pages.yml
+++ b/.github/workflows/_shared-docs-build-publish-gh-pages.yml
@@ -87,8 +87,10 @@ jobs:
         run: mkdir -p html
 
       - name: Publish
-        # if: inputs.action == 'publish'
-        uses: peaceiris/actions-gh-pages@v3
+        # this action uses a token with contents:write, pinning to commit
+        # 068dc23d9710f1ba62e86896f84735d869951305 == v3.8.0
+        # https://github.com/peaceiris/actions-gh-pages/releases/tag/v3.8.0
+        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           publish_dir: html


### PR DESCRIPTION
This is a reusable workflow for publishing to GitHub Pages. 

This is intended to be an opinionated, specific way of doing so that supports multiple simultaneous docs builds within a single GitHub Pages site, not a general workflow to have a high degree of customizability.

The reason for that, is that the bulk of the "work" of publishing to GH pages is handled by a single action, [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages), which can be used directly for anyone wishing to do something simpler or more custom. Alternatively, "publishing" to GitHub Pages is done via commit and push, so users who don't want to use the action can similarly put something together using git commands.

Or this workflow can have the `destination-dir` overridden, which is really where our convention is applied.

### About the convention used
When `destination-dir` is not set, this workflow puts docs into sub-directories in the published site based on the event:
- for a pull request, the site is published to `/pr/XX` where `XX` is the PR number, for example: `/pr/123`
- for a push to a branch, the site is published to `/branch/NAME`, for example: `/branch/main` or `/branch/stable-3`
- for a push to a tag, the site is published to `/tag/TAG`, for example: `/tag/3.21.7`

Since the consumer of the workflow completely controls the triggers of their calling workflow, anyone who wants to limit which sites get published can do so by limiting the workflow triggers (triggering on only PRs or pushes, limiting the branches and tags, etc.); this does not need customization in the workflow.

I will post a getting started guide to initially setting up GH pages, but it is pretty straightforward.

---

## Not supported
- intermingling with an existing GH pages site (could work with static [non-jekyll] site if you understand the directory structures, use at your own risk)
- publishing to a GH pages site in another repo (this one is quite possible to implement, and may be desirable for some, good future improvement)
- single commit/orphan commit/force push (this is something I want to support, as it will help keep bloat down, but at the moment can't be done with our convention until maybe v4 of the action we use: https://github.com/peaceiris/actions-gh-pages/issues/455)
- other things I didn't call out explicitly

Also, right now there's no straightforward way to have this publish arbitrary branches/tags that were pushed before this was in place. It can be done (in the consuming repo) by adding a `workflow_dispatch` trigger with an input of the branch or tag, and then you'd have to set `destination-dir` yourself following the convention. That would work for one-at-a-time. For outside of actions, some separate script could render all the docs for the various refs, put them in the correct directories, and push them up.