### PR TITLE
workflow shared-docs-build-push: add `artifact-upload` and `build-ref` options

### DIFF
--- a/.github/workflows/_shared-docs-build-push.yml
+++ b/.github/workflows/_shared-docs-build-push.yml
@@ -48,6 +48,11 @@ on:
           If not supplied, the latest version from PyPI is used. If supplied, must be a git ref from the antsibull-docs repository.
         required: false
         type: string
+      artifact-upload:
+        description: Whether or not to upload the build as an artifact.
+        type: boolean
+        required: false
+        default: true
       artifact-name:
         description: The name of the artifact to upload.
         required: false
@@ -150,3 +155,4 @@ jobs:
           build-script: ${{ steps.init.outputs.build-script }}
           build-html: ${{ steps.init.outputs.build-html }}
           artifact-name: ${{ inputs.artifact-name }}
+          artifact-upload: ${{ inputs.artifact-upload }}

--- a/.github/workflows/_shared-docs-build-push.yml
+++ b/.github/workflows/_shared-docs-build-push.yml
@@ -22,6 +22,12 @@ on:
         required: false
         type: string
         default: stable-2.13
+      build-ref:
+        description: |
+          The ref from this repository to check out and build.
+          The default is the default of the actions/checkout action.
+        required: false
+        type: string
       init-dest-dir:
         description: A directory relative to the checkout where the init process has already been run.
         required: false
@@ -124,6 +130,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ${{ steps.vars.outputs.checkout-path }}
+          ref: ${{ inputs.build-ref }}
 
       - name: Initialize the build environment
         id: init


### PR DESCRIPTION
This modifies the push build workflow so that you can:
- specify whether or not to upload the build as an artifact (defaults to `true`, no change in behavior)
- specify which ref to checkout (defaults to none which defaults to actions/checkout default, no change in behavior)

These changes make the workflow useful for running a "validation" job, by changing the lenient and fail-on-error options. This was already possible for push workflows, but the artifact uploaded was redundant and couldn't be turned off.

For PRs, this was not possible with `pull_request_target` events (which we usually use) because we had no way to tell the workflow to use the PR ref (the default would have been the PR target, like `main`). Now we can tell the workflow to use the merge commit or whatever on PRs.

# Examples

(Currently shown referencing this PR's version of the workflow)

### PR

```yaml
name: Collection Docs
concurrency:
  group: docs-pr-${{ github.head_ref }}
  cancel-in-progress: true
on:
  pull_request_target:
    types: [opened, synchronize, reopened, closed]

jobs:
  validate-docs:
    permissions:
      contents: read
    name: Validate Ansible Docs
    if: github.event.action != 'closed'
    uses: briantist/github-docs-build/.github/workflows/_shared-docs-build-push.yml@workflows/build-push/choose-ref
    with:
      artifact-upload: false
      init-lenient: false
      init-fail-on-error: true
      build-ref: refs/pull/${{ github.event.number }}/merge
```

### Push

```yaml
name: Collection Docs
concurrency:
  group: docs-push-${{ github.head_ref }}
  cancel-in-progress: true
on:
  push:
    branches:
      - main
      - stable-*
    tags:
      - '*'

jobs:
  validate-docs:
    permissions:
      contents: read
    name: Validate Ansible Docs
    uses: briantist/github-docs-build/.github/workflows/_shared-docs-build-push.yml@workflows/build-push/choose-ref
    with:
      artifact-upload: false
      init-lenient: false
      init-fail-on-error: true
```