### PR TITLE
Add some content into the _targets.rst file

### DIFF
--- a/actions/ansible-docs-build-init/action.yml
+++ b/actions/ansible-docs-build-init/action.yml
@@ -84,6 +84,10 @@ runs:
             while read -r line; do
               echo ".. _${line}:" >> "${{ inputs.dest-dir }}/rst/_targets.rst"
             done <<< "${_INPUT_PROVIDE_LINK_TARGETS}"
+            echo "" >> "${{ inputs.dest-dir }}/rst/_targets.rst"
+            echo "Replacement stub for existing reference" >> "${{ inputs.dest-dir }}/rst/_targets.rst"
+            echo "=======================================" >> "${{ inputs.dest-dir }}/rst/_targets.rst"
+            echo "" >> "${{ inputs.dest-dir }}/rst/_targets.rst"
             echo "This file just exists to provide link targets. Please ignore it." >> "${{ inputs.dest-dir }}/rst/_targets.rst"
             echo "::endgroup::"
         fi


### PR DESCRIPTION
Should fix https://github.com/ansible-collections/community.general/runs/7003212532?check_suite_focus=true, which fails because of
```
  /home/runner/work/_temp/docsbuild/base/rst/_targets.rst:2: WARNING: Field list ends without a blank line; unexpected unindent.
  /home/runner/work/_temp/docsbuild/base/rst/_targets.rst:30: WARNING: malformed hyperlink target.
  /home/runner/work/_temp/docsbuild/base/rst/_targets.rst:31: WARNING: Explicit markup ends without a blank line; unexpected unindent.  
```