### PR TITLE
Fix _targets.rst file: add needed newline, prevent bad labels due to empty lines

### DIFF
--- a/actions/ansible-docs-build-init/action.yml
+++ b/actions/ansible-docs-build-init/action.yml
@@ -81,14 +81,20 @@ runs:
             echo "::group::Create small RST file for link"
             mkdir -p "${{ inputs.dest-dir }}/rst"
             echo ":orphan:" > "${{ inputs.dest-dir }}/rst/_targets.rst"
+            echo "" >> "${{ inputs.dest-dir }}/rst/_targets.rst"
             while read -r line; do
-              echo ".. _${line}:" >> "${{ inputs.dest-dir }}/rst/_targets.rst"
+              if [ "${line}" != "" ]; then
+                echo ".. _${line}:" >> "${{ inputs.dest-dir }}/rst/_targets.rst"
+              fi
             done <<< "${_INPUT_PROVIDE_LINK_TARGETS}"
             echo "" >> "${{ inputs.dest-dir }}/rst/_targets.rst"
             echo "Replacement stub for existing reference" >> "${{ inputs.dest-dir }}/rst/_targets.rst"
             echo "=======================================" >> "${{ inputs.dest-dir }}/rst/_targets.rst"
             echo "" >> "${{ inputs.dest-dir }}/rst/_targets.rst"
             echo "This file just exists to provide link targets. Please ignore it." >> "${{ inputs.dest-dir }}/rst/_targets.rst"
+            echo "Content of ${{ inputs.dest-dir }}/rst/_targets.rst:"
+            echo ""
+            cat "${{ inputs.dest-dir }}/rst/_targets.rst"
             echo "::endgroup::"
         fi
 


### PR DESCRIPTION
See https://github.com/ansible-collections/community.general/runs/7003339788?check_suite_focus=true
```
  /home/runner/work/_temp/docsbuild/base/rst/_targets.rst:2: WARNING: Field list ends without a blank line; unexpected unindent.
  /home/runner/work/_temp/docsbuild/base/rst/_targets.rst:30: WARNING: malformed hyperlink target.
```