### PR TITLE
Bump stable-2.13 to stable-2.14

### DIFF
--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -18,10 +18,10 @@ on:
         type: string
         default: '3.9'
       ansible-ref:
-        description: The ref from which to install ansible, for example "stable-2.13" or "milestone".
+        description: The ref from which to install ansible, for example "stable-2.14" or "milestone".
         required: false
         type: string
-        default: stable-2.13
+        default: stable-2.14
       init-dest-dir:
         description: A directory relative to the checkout where the init process has already been run.
         required: false

--- a/.github/workflows/_shared-docs-build-push.yml
+++ b/.github/workflows/_shared-docs-build-push.yml
@@ -18,10 +18,10 @@ on:
         type: string
         default: '3.9'
       ansible-ref:
-        description: The ref from which to install ansible, for example "stable-2.13" or "milestone".
+        description: The ref from which to install ansible, for example "stable-2.14" or "milestone".
         required: false
         type: string
-        default: stable-2.13
+        default: stable-2.14
       build-ref:
         description: |
           The ref from this repository to check out and build.


### PR DESCRIPTION
Now that stable-2.14 has been branched, switch to that one since it supports rendering test and filter docs :tada: