### PR TITLE
Fix typo introduced in #58

### DIFF
--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -248,7 +248,7 @@ jobs:
           fail-on-error: false
           provide-link-targets: ${{ inputs.provide-link-targets }}
           intersphinx-links: ${{ inputs.intersphinx-links }}
-          squash-hierarchy: ${{ input.squash-hierarchy }}
+          squash-hierarchy: ${{ inputs.squash-hierarchy }}
 
       - name: Build BASE
         id: build-base

--- a/.github/workflows/_shared-docs-build-push.yml
+++ b/.github/workflows/_shared-docs-build-push.yml
@@ -166,7 +166,7 @@ jobs:
           fail-on-error: ${{ inputs.init-fail-on-error }}
           provide-link-targets: ${{ inputs.provide-link-targets }}
           intersphinx-links: ${{ inputs.intersphinx-links }}
-          squash-hierarchy: ${{ input.squash-hierarchy }}
+          squash-hierarchy: ${{ inputs.squash-hierarchy }}
 
       - name: Build
         id: build


### PR DESCRIPTION
It looks like the shared workflows in #58 had typos. Unfortunately they aren't tested, so I only noticed after merging :(