### PR TITLE
Add a way to modify the antsibull-docs repository used when installing antsibull-docs

### DIFF
--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -46,6 +46,13 @@ on:
           If not supplied, the latest version from PyPI is used. If supplied, must be a git ref from the antsibull-docs repository.
         required: false
         type: string
+      init-antsibull-docs-repository:
+        description: |
+          When init-antsibull-docs-version is specified, this is the GitHub repository to which init-antsibull-docs-version refers.
+          Has no effect if init-dest-dir is supplied, or if init-antsibull-docs-version is not supplied.
+        required: false
+        type: string
+        default: ansible-community/antsibull-docs
       artifact-name:
         description: The name of the artifact to upload.
         required: false
@@ -245,6 +252,7 @@ jobs:
           dest-dir: ${{ steps.vars.outputs.init-dir-base }}
           skip-init: ${{ steps.vars.outputs.skip-init }}
           antsibull-docs-version: '${{ inputs.init-antsibull-docs-version }}'
+          antsibull-docs-repository: '${{ inputs.init-antsibull-docs-repository }}'
           lenient: true
           fail-on-error: false
           provide-link-targets: ${{ inputs.provide-link-targets }}
@@ -280,6 +288,7 @@ jobs:
           dest-dir: ${{ steps.vars.outputs.init-dir-head }}
           skip-init: ${{ steps.vars.outputs.skip-init }}
           antsibull-docs-version: '${{ inputs.init-antsibull-docs-version }}'
+          antsibull-docs-repository: '${{ inputs.init-antsibull-docs-repository }}'
           lenient: ${{ inputs.init-lenient }}
           fail-on-error: ${{ inputs.init-fail-on-error }}
           provide-link-targets: ${{ inputs.provide-link-targets }}

--- a/.github/workflows/_shared-docs-build-push.yml
+++ b/.github/workflows/_shared-docs-build-push.yml
@@ -48,6 +48,13 @@ on:
           If not supplied, the latest version from PyPI is used. If supplied, must be a git ref from the antsibull-docs repository.
         required: false
         type: string
+      init-antsibull-docs-repository:
+        description: |
+          When init-antsibull-docs-version is specified, this is the GitHub repository to which init-antsibull-docs-version refers.
+          Has no effect if init-dest-dir is supplied, or if init-antsibull-docs-version is not supplied.
+        required: false
+        type: string
+        default: ansible-community/antsibull-docs
       artifact-upload:
         description: Whether or not to upload the build as an artifact.
         type: boolean
@@ -163,6 +170,7 @@ jobs:
           dest-dir: ${{ steps.vars.outputs.init-dir }}
           skip-init: ${{ steps.vars.outputs.skip-init }}
           antsibull-docs-version: '${{ inputs.init-antsibull-docs-version }}'
+          antsibull-docs-repository: '${{ inputs.init-antsibull-docs-repository }}'
           lenient: ${{ inputs.init-lenient }}
           fail-on-error: ${{ inputs.init-fail-on-error }}
           provide-link-targets: ${{ inputs.provide-link-targets }}

--- a/actions/ansible-docs-build-init/action.yml
+++ b/actions/ansible-docs-build-init/action.yml
@@ -36,6 +36,12 @@ inputs:
       The version of antsibull-docs to install. When set, it refers to a git ref from which to install.
       If not set, the latest version from PyPI is installed.
     required: false
+  antsibull-docs-repository:
+    description: |
+      When antsibull-docs-version is specified, this is the GitHub repository to which antsibull-docs-version refers.
+      Has no effect if antsibull-docs-version is not supplied.
+    default: ansible-community/antsibull-docs
+    required: false
   provide-link-targets:
     description: A newline separated list of link targets that should not cause reference errors. A small RST file will be created during the build which contains these labels.
     required: false
@@ -74,7 +80,7 @@ runs:
       run: |
         echo "::group::Installing antsibull-docs"
         if [[ "${{ inputs.antsibull-docs-version }}" != "" ]] ; then
-            pip install https://github.com/ansible-community/antsibull-docs/archive/${{ inputs.antsibull-docs-version }}.tar.gz
+            pip install https://github.com/${{ inputs.antsibull-docs-repository || 'ansible-community/antsibull-docs' }}/archive/${{ inputs.antsibull-docs-version }}.tar.gz
         else
             pip install antsibull-docs
         fi

--- a/actions/ansible-docs-build-init/action.yml
+++ b/actions/ansible-docs-build-init/action.yml
@@ -80,7 +80,7 @@ runs:
       run: |
         echo "::group::Installing antsibull-docs"
         if [[ "${{ inputs.antsibull-docs-version }}" != "" ]] ; then
-            pip install https://github.com/${{ inputs.antsibull-docs-repository || 'ansible-community/antsibull-docs' }}/archive/${{ inputs.antsibull-docs-version }}.tar.gz
+            pip install https://github.com/${{ inputs.antsibull-docs-repository }}/archive/${{ inputs.antsibull-docs-version }}.tar.gz
         else
             pip install antsibull-docs
         fi


### PR DESCRIPTION
Allows to use branches form other forks of antsibull-docs.

I'm using another branch (https://github.com/ansible-community/github-docs-build/compare/main...felixfontein:github-docs-build:repo) to test this in community.dns (https://github.com/ansible-collections/community.dns/commit/075d3a098438e54fffb3630c75b698fd237df1ed, https://github.com/ansible-collections/community.dns/pull/23).