### PR TITLE
Bump peaceiris/actions-gh-pages to 3.9.0.

### DIFF
--- a/.github/workflows/_shared-docs-build-publish-gh-pages.yml
+++ b/.github/workflows/_shared-docs-build-publish-gh-pages.yml
@@ -91,9 +91,9 @@ jobs:
 
       - name: Publish
         # this action uses a token with contents:write, pinning to commit
-        # 068dc23d9710f1ba62e86896f84735d869951305 == v3.8.0
-        # https://github.com/peaceiris/actions-gh-pages/releases/tag/v3.8.0
-        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305
+        # de7ea6f8efb354206b205ef54722213d99067935 == v3.9.0
+        # https://github.com/peaceiris/actions-gh-pages/releases/tag/v3.9.0
+        uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           publish_dir: html


### PR DESCRIPTION
Right now the shared workflow triggers a warning (`Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305`). Let's upgrade the action to 3.9.0 which fixes that (https://github.com/peaceiris/actions-gh-pages/blob/v3.9.0/CHANGELOG.md#feat).