### PR TITLE
PR build: use base ref instead of base sha to checkout BASE

### DIFF
--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -287,7 +287,12 @@ jobs:
       - name: Checkout BASE
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          # Use base.ref, not base.sha, to make sure we do not get a checkout of the base at an earlier time
+          # (when the PR's branch was branched off the PR's target branch), but right now. Without this there
+          # will be a potentially large list of changes since the merge commit we check out for HEAD is based
+          # on a far newer version. I'm not 100% sure whether this is also a good idea for the closed event
+          # though...
+          ref: ${{ github.event.pull_request.base.ref }}
           path: ${{ steps.vars.outputs.checkout-path }}
 
       - name: Initialize the build environment (BASE)


### PR DESCRIPTION
I was wondering a long time why #14 didn't seem to help, since in particular in community.general every bump of galaxy.yml in `main` caused all PRs created before that version bump to have an error in the docs build (argument list too long on computing the diff), resp. in other collections to have a long list of changes. Example: https://github.com/ansible-collections/community.general/actions/runs/4052090683/jobs/6971113426

While staring at the problem again today I noticed that we're using `base.sha`, which is a fixed commit. It seems to be the commit the PR's branch was branched from (since it changes when the branch is rebased). But since HEAD is the merge commit on the *latest* version of the target branch, that commit is "too old". I'm not 100% sure whether base.ref is the correct value (I assume it happens to be `main` if the PR target branch is `main`, but I'm not 100% sure), but if it is then this should improve the situation.