### PR TITLE
Bump ansible-core and Python versions

### DIFF
--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -16,12 +16,12 @@ on:
         description: The version of Python to install.
         required: false
         type: string
-        default: '3.9'
+        default: '3.10'
       ansible-ref:
         description: The ref from which to install ansible, for example "stable-2.14" or "milestone".
         required: false
         type: string
-        default: stable-2.14
+        default: stable-2.15
       init-dest-dir:
         description: A directory relative to the checkout where the init process has already been run.
         required: false

--- a/.github/workflows/_shared-docs-build-push.yml
+++ b/.github/workflows/_shared-docs-build-push.yml
@@ -16,12 +16,12 @@ on:
         description: The version of Python to install.
         required: false
         type: string
-        default: '3.9'
+        default: '3.10'
       ansible-ref:
         description: The ref from which to install ansible, for example "stable-2.14" or "milestone".
         required: false
         type: string
-        default: stable-2.14
+        default: stable-2.15
       build-ref:
         description: |
           The ref from this repository to check out and build.

--- a/.github/workflows/generate-wiki-docs.yml
+++ b/.github/workflows/generate-wiki-docs.yml
@@ -35,11 +35,11 @@ jobs:
       - uses: actions/setup-python@v4
         if: fromJSON(env.SHOULD_RUN)
         with:
-          python-version: '3.9'
+          python-version: '3.11'
 
       - name: Install Ansible
         if: fromJSON(env.SHOULD_RUN)
-        run: pip install 'ansible-core>=2.12,<2.13' --disable-pip-version-check
+        run: pip install 'ansible-core>=2.15,<2.16' --disable-pip-version-check
 
       - name: Generate new docs
         if: fromJSON(env.SHOULD_RUN)

--- a/.github/workflows/test-action-build-init.yml
+++ b/.github/workflows/test-action-build-init.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       # if we pass an empty string to dest-dir, it will override the default.
       # we can't copy the default into the matrix because it uses a templating


### PR DESCRIPTION
Ref: https://github.com/ansible-collections/news-for-maintainers/issues/48

- Use Python 3.11 for build action testing.
- Use ansible-core 2.15 on Python 3.11 for Wiki.
- Bump defaults for shared workflows to stable-2.15 and Python 3.10.
