### PR TITLE
Use Dependabot also for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,19 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/actions/ansible-docs-build-comment"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/actions/ansible-docs-build-diff"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/actions/ansible-docs-build-html"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/actions/ansible-docs-build-init"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
It seems that by default it only updates the workflows, but not the actions.

Adding entries for the actions should solve this. I hope :)
