### PR TITLE
Bump peaceiris/actions-gh-pages action.

### DIFF
--- a/.github/workflows/_shared-docs-build-publish-gh-pages.yml
+++ b/.github/workflows/_shared-docs-build-publish-gh-pages.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Publish
         # this action uses a token with contents:write, pinning to commit
-        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
+        uses: peaceiris/actions-gh-pages@4eb285e828117bca26638192c3ed309c622e7bad # v3.9.3
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           publish_dir: html


### PR DESCRIPTION
This includes the latest commit, https://github.com/peaceiris/actions-gh-pages/commit/4eb285e828117bca26638192c3ed309c622e7bad, which removes the annoying warning.

Changes: https://github.com/peaceiris/actions-gh-pages/compare/373f7f263a76c20808c831209c920827a82a2847..4eb285e828117bca26638192c3ed309c622e7bad

Unfortunately there is no new release yet, so I've used the commit hash of the latest commit (which happens to be the commit bumping Node).

I have not updated the version comment in the hope that Dependabot will do this soon when a new version is out (which I hope will be soon, no idea whether that will actually happen). I'm not sure whether this is a good idea, since now the comment is definitely incorrect. @briantist WDYT?