### PR TITLE
Add option publish-gh-pages-branch

### DIFF
--- a/.github/workflows/_shared-docs-build-publish-gh-pages.yml
+++ b/.github/workflows/_shared-docs-build-publish-gh-pages.yml
@@ -29,6 +29,12 @@ on:
         required: false
         type: string
         default: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+      publish-gh-pages-branch:
+        description: |
+          Whether to publish the `gh-pages` branch to GitHub Pages.
+        required: false
+        type: boolean
+        default: false
     outputs:
       url:
         description: The destination path pre-pended with the base-url.
@@ -39,12 +45,17 @@ on:
           The token used for publishing to GitHub Pages.
           Even when using the workflow token (secrets.GITHUB_TOKEN), it must be passed explicitly.
         required: true
+concurrency:  # Do not run workflow in parallel!
+  cancel-in-progress: false
+  group: pages
 jobs:
   publish-gh-pages:
     name: Publish to GitHub Pages
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pages: write
+      id-token: write
     outputs:
       url: ${{ steps.vars.outputs.url }}
     steps:
@@ -100,3 +111,30 @@ jobs:
           # NOTE: do not use the force_orphan (keep_history) option.
           # It does not yet work correctly with keep_files and destination_dir:
           # - https://github.com/peaceiris/actions-gh-pages/issues/455
+
+      - name: Checkout repository
+        if: inputs.publish-gh-pages-branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages-checkout
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Setup GitHub Pages
+        if: inputs.publish-gh-pages-branch
+        uses: actions/configure-pages@v5
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Upload gh-pages branch as artifact
+        if: inputs.publish-gh-pages-branch
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: gh-pages-checkout
+
+      - name: Deploy gh-pages branch to GitHub Pages
+        if: inputs.publish-gh-pages-branch
+        id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          token: ${{ secrets.GH_TOKEN }}

--- a/samples/pr-build-and-comment.yml
+++ b/samples/pr-build-and-comment.yml
@@ -36,12 +36,15 @@ jobs:
     if: github.repository == 'repo_owner/repo_name'
     permissions:
       contents: write
+      pages: write
+      id-token: write
     needs: [build-docs]
     name: Publish Ansible Docs
     uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-publish-gh-pages.yml@main
     with:
       artifact-name: ${{ needs.build-docs.outputs.artifact-name }}
       action: ${{ (github.event.action == 'closed' || needs.build-docs.outputs.changed != 'true') && 'teardown' || 'publish' }}
+      publish-gh-pages-branch: true
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/samples/pr-with-publish-to-gh-pages.yml
+++ b/samples/pr-with-publish-to-gh-pages.yml
@@ -40,12 +40,15 @@ jobs:
     if: github.repository == 'repo_owner/repo_name'
     permissions:
       contents: write
+      pages: write
+      id-token: write
     needs: [build-docs]
     name: Publish Ansible Docs
     uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-publish-gh-pages.yml@main
     with:
       artifact-name: ${{ needs.build-docs.outputs.artifact-name }}
       action: ${{ (github.event.action == 'closed' || needs.build-docs.outputs.changed != 'true') && 'teardown' || 'publish' }}
+      publish-gh-pages-branch: true
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/samples/push-with-publish-to-gh-pages.yml
+++ b/samples/push-with-publish-to-gh-pages.yml
@@ -26,10 +26,13 @@ jobs:
     if: github.repository == 'repo_owner/repo_name'
     permissions:
       contents: write
+      pages: write
+      id-token: write
     needs: [build-docs]
     name: Publish Ansible Docs
     uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-publish-gh-pages.yml@main
     with:
       artifact-name: ${{ needs.build-docs.outputs.artifact-name }}
+      publish-gh-pages-branch: true
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I've tried integrating updating GH Pages into the shared workflow (`_shared-docs-build-publish-gh-pages.yml`), and after some tries it seems to work. This PR adds a new option, `publish-gh-pages-branch`, which needs to be explicitly enabled like this: https://github.com/ansible-collections/community.hrobot/commit/933f952c14072f635fb43c35f94dfe9459007fc5 (obviously without pointing to the workflow in my branch once this is merged ;) )

Successful run: https://github.com/ansible-collections/community.hrobot/actions/runs/9702624870. That run made https://ansible-collections.github.io/community.hrobot/pr/114/firewall_module.html#synopsis show `Test!` as the last paragraph of the `Description` (before it was `test`).

I'm not sure whether this is the best solution, and I'm also a bit surprised that not having `environment: github-pages` there works. (I had it in the shared workflow first, that made it fail.)
