### PR TITLE
Fix copy'n'paste error in tests

### DIFF
--- a/.github/workflows/test-action-build-html.yml
+++ b/.github/workflows/test-action-build-html.yml
@@ -226,7 +226,7 @@ jobs:
         run: |
           import os
 
-          expected_hash = os.environ['expected_hash ']
+          expected_hash = os.environ['expected_hash']
           output_hash = os.environ['output_hash']
           output_build_html = os.environ['output_build_html']
           artifact_hash = os.environ['artifact_hash']

--- a/.github/workflows/test-action-build-html.yml
+++ b/.github/workflows/test-action-build-html.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           import os
 
-          expected_hash = os.environ['ARTIFACT_HASH']
+          expected_hash = os.environ['EXPECTED_HASH']
           output_hash = os.environ['OUTPUT_HASH']
           output_build_html = os.environ['OUTPUT_BUILD_HTML']
           artifact_hash = os.environ['ARTIFACT_HASH']


### PR DESCRIPTION
#96 broke one test: https://github.com/ansible-community/github-docs-build/actions/runs/12331168792/job/34417458802

It's kind of annoying that this didn't fail in the PR, but only after merging...