### PR TITLE
Make sure variables are taken from environment before being used

### DIFF
--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -249,6 +249,8 @@ jobs:
             core.setOutput('col-path', colpath)
             core.setOutput('checkout-path', checkoutPath)
 
+            const { RUNNER_TEMP, EVENT_ACTION, MERGE_COMMIT_SHA, GITHUB_EVENT_NUMBER } = process.env
+
             var initPath = `${RUNNER_TEMP}/docsbuild`
             var skipInit = false
 

--- a/.github/workflows/_shared-docs-build-push.yml
+++ b/.github/workflows/_shared-docs-build-push.yml
@@ -183,6 +183,8 @@ jobs:
             core.setOutput('col-path', colpath)
             core.setOutput('checkout-path', checkoutPath)
 
+            const { RUNNER_TEMP } = process.env
+
             var initPath = `${RUNNER_TEMP}/docsbuild`
             var skipInit = false
 


### PR DESCRIPTION
There's another bug in #96 which I unfortunately only noticed after merging some PRs, since the PR docs workflow in community.docker for some reason still used an older branch of mine instead of `main` of this repo... In any case, when reading https://github.com/actions/github-script?tab=readme-ov-file#use-env-as-input I apparently missed the most important part...