### PR TITLE
Replace `ANSIBLE_COLLECTIONS_PATHS` with `ANSIBLE_COLLECTIONS_PATH`

### DIFF
--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -242,7 +242,7 @@ jobs:
                 colpath = inputs['collection-name'].replace('.', '/')
             }
 
-            core.exportVariable('ANSIBLE_COLLECTIONS_PATHS', process.env.GITHUB_WORKSPACE)
+            core.exportVariable('ANSIBLE_COLLECTIONS_PATH', process.env.GITHUB_WORKSPACE)
 
             const checkoutPath = `ansible_collections/${colpath}`
 

--- a/.github/workflows/_shared-docs-build-push.yml
+++ b/.github/workflows/_shared-docs-build-push.yml
@@ -175,7 +175,7 @@ jobs:
                 colpath = colname.replace('.', '/')
             }
 
-            core.exportVariable('ANSIBLE_COLLECTIONS_PATHS', process.env.GITHUB_WORKSPACE)
+            core.exportVariable('ANSIBLE_COLLECTIONS_PATH', process.env.GITHUB_WORKSPACE)
 
             const checkoutPath = `ansible_collections/${colpath}`
 

--- a/.github/workflows/generate-wiki-docs.yml
+++ b/.github/workflows/generate-wiki-docs.yml
@@ -19,7 +19,7 @@ jobs:
   generate:
     env:
       WIKI: ${{ github.workspace }}/wiki
-      ANSIBLE_COLLECTIONS_PATHS: ${{ github.workspace }}/.internal/ansible
+      ANSIBLE_COLLECTIONS_PATH: ${{ github.workspace }}/.internal/ansible
     runs-on: ubuntu-latest
     steps:
       - if: fromJSON(env.SHOULD_RUN)


### PR DESCRIPTION
Ansible-core 2.19 removed support for `ANSIBLE_COLLECTIONS_PATHS`, and I don't think we have to care about Ansible 2.9 support anymore.

(This broke community.aws' docs workflows, since they're using `ansible-ref: devel`. It stopped working some months ago, probably when `devel` removed support for `ANSIBLE_COLLECTIONS_PATHS`... That happened in https://github.com/ansible/ansible/commit/f29b46e43828d2935e78e988771523b95786b11a, so it likely stopped working already in October 2024...)