### PR TITLE
Fix the GH publish workflow if `publish-gh-pages-branch` is `false`

### DIFF
--- a/.github/workflows/_shared-docs-build-publish-gh-pages.yml
+++ b/.github/workflows/_shared-docs-build-publish-gh-pages.yml
@@ -89,7 +89,6 @@ jobs:
           exit 1
 
       - name: Checkout repository
-        if: inputs.publish-gh-pages-branch
         uses: actions/checkout@v6
         with:
           ref: gh-pages


### PR DESCRIPTION
Ref: https://github.com/ansible-community/github-docs-build/pull/110#issuecomment-4364017032

We now also need the checkout if `publish-gh-pages-branch` is `false`.