### PR TITLE
Do not fail when there are no files to add

### DIFF
--- a/.github/workflows/_shared-docs-build-publish-gh-pages.yml
+++ b/.github/workflows/_shared-docs-build-publish-gh-pages.yml
@@ -121,7 +121,7 @@ jobs:
           COMMIT_MSG: |-
             deploy: ${{ github.sha }}
         run: |
-          git add "${DEST_DIR}"
+          git add "${DEST_DIR}" || true
           git config --global user.name "${COMMIT_USERNAME}"
           git config --global user.email "${COMMIT_EMAIL}"
           git commit -m "${COMMIT_MSG}" || true


### PR DESCRIPTION
Another follow-up to #110: if there's nothing to add, the workflow currently fails - see for example https://github.com/ansible-collections/community.hrobot/actions/runs/25258224007/job/74061068016?pr=191 or https://github.com/ansible-collections/community.routeros/actions/runs/25258225320/job/74061072776?pr=464.