### PR TITLE
Run checkout GHA with allow-unsafe-pr-checkout=true in shared PR workflow

### DIFF
--- a/.github/workflows/_shared-docs-build-pr.yml
+++ b/.github/workflows/_shared-docs-build-pr.yml
@@ -352,6 +352,9 @@ jobs:
           ref: ${{ steps.vars.outputs.pr-checkout-ref }}
           path: ${{ steps.vars.outputs.checkout-path }}
           persist-credentials: false
+          # Since checkout v7, we have to explicitly allow unsafe use.
+          # We can remove this if we explicitly specify `ref` as above.
+          allow-unsafe-pr-checkout: true
 
       - name: Initialize the build environment (HEAD)
         id: init-head


### PR DESCRIPTION
Ref: https://github.com/ansible-community/github-docs-build/pull/113#issuecomment-4765124824

Example failure: https://github.com/ansible-collections/community.docker/actions/runs/27930608676/job/82641598592?pr=1286