### PR TITLE
Run checkout GHA with allow-unsafe-pr-checkout=true in shared PUSH workflow

### DIFF
--- a/.github/workflows/_shared-docs-build-push.yml
+++ b/.github/workflows/_shared-docs-build-push.yml
@@ -222,6 +222,8 @@ jobs:
           path: ${{ steps.vars.outputs.checkout-path }}
           ref: ${{ inputs.build-ref }}
           persist-credentials: false
+          # Since checkout v7, we have to explicitly allow unsafe use.
+          allow-unsafe-pr-checkout: true
 
       - name: Initialize the build environment
         id: init


### PR DESCRIPTION
Same as: https://github.com/ansible-community/github-docs-build/pull/114
For _shared-docs-build-push workflow.