### PR TITLE
Run checkout GHA with allow-unsafe-pr-checkout=true in shared push workflow

### DIFF
--- a/.github/workflows/_shared-docs-build-push.yml
+++ b/.github/workflows/_shared-docs-build-push.yml
@@ -222,7 +222,10 @@ jobs:
           path: ${{ steps.vars.outputs.checkout-path }}
           ref: ${{ inputs.build-ref }}
           persist-credentials: false
-
+          # Since checkout v7, we have to explicitly allow unsafe use.
+          # We can remove this if we explicitly specify `ref` as above.
+          allow-unsafe-pr-checkout: true
+          
       - name: Initialize the build environment
         id: init
         uses: ansible-community/github-docs-build/actions/ansible-docs-build-init@main


### PR DESCRIPTION
Same as #114 but for push.

I use the push workflow with modified options as a "strict" validator in PRs for example.

See: 
* https://github.com/ansible-collections/community.hashi_vault/blob/a6d72a05f8d3aa96d158e2c82fb6d7140ffdadd6/.github/workflows/docs.yml#L15-L41
* https://github.com/ansible-collections/community.hashi_vault/actions/runs/29167814396/job/86583909112?pr=500